### PR TITLE
32 basic database functions

### DIFF
--- a/.env.example (backend)
+++ b/.env.example (backend)
@@ -2,3 +2,4 @@ JWT_SECRET_KEY=your_jwt_secret_key
 NEO4J_URL=bolt://localhost:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=password
+NEO4J_DB_NAME=neo4j

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -107,7 +107,10 @@ class database:
         Set specific node property with new data.
         """
         id_value = str(id_value)
-        query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) SET n." + property_name + " = $old_data"
+        query_string = (
+            "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) "
+            "SET n." + property_name + " = $old_data" 
+        )
 
         self.__driver.execute_query(
             query_string,
@@ -122,8 +125,11 @@ class database:
         Lookup a node and return all it's data
         """
         id_value = str(id_value)
-        query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) RETURN n"
-        
+        query_string = (
+            "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) "
+            "RETURN n"
+        )
+
         records, summary, keys = self.__driver.execute_query(
             query_string,
             database_= self.__name,
@@ -140,7 +146,10 @@ class database:
         Lookup individual property value from a node
         """
         id_value = str(id_value)
-        query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) RETURN n." + property_name + " AS " + property_name
+        query_string = (
+            "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) "
+            "RETURN n." + property_name + " AS " + property_name
+        )
         
         records, summary, keys = self.__driver.execute_query(
             query_string,
@@ -159,12 +168,29 @@ class database:
         """
         id_value = str(id_value)
         if exclude_relationships == None:
-            query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) <- [*0..] - (d) DETACH DELETE n WITH DISTINCT d DETACH DELETE d"
+            query_string = (
+                "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) <- [*0..] - (d) "
+                "DETACH DELETE n "
+                "WITH DISTINCT d "
+                "DETACH DELETE d"
+            )
         elif isinstance(exclude_relationships,list):
             exclude_relationships = "','".join(exclude_relationships)
-            query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) <- [r*0..] - (d) WHERE NONE ( rel IN r WHERE type(rel) IN ['"+ exclude_relationships + "']) DETACH DELETE n WITH DISTINCT d DETACH DELETE d"
+            query_string = (
+                "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) <- [r*0..] - (d) "
+                "WHERE NONE ( rel IN r WHERE type(rel) IN ['"+ exclude_relationships + "']) "
+                "DETACH DELETE n "
+                "WITH DISTINCT d "
+                "DETACH DELETE d"
+            )
         elif isinstance(exclude_relationships,str):
-            query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) <- [r*0..] - (d) WHERE NONE ( rel IN r WHERE type(rel) = '"+ exclude_relationships + "') DETACH DELETE n WITH DISTINCT d DETACH DELETE d"
+            query_string = (
+                "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) <- [r*0..] - (d) "
+                "WHERE NONE ( rel IN r WHERE type(rel) = '"+ exclude_relationships + "') "
+                "DETACH DELETE n "
+                "WITH DISTINCT d "
+                "DETACH DELETE d"
+            )
         else:
             return "ERROR: exclude_relationships was something else than None, string or list of string"
         
@@ -179,7 +205,10 @@ class database:
         Delete a node and it's connections
         """
         id_value = str(id_value)
-        query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) DETACH DELETE n"
+        query_string = (
+            "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) "
+            "DETACH DELETE n"
+        )
         
         self.__driver.execute_query(
             query_string,
@@ -193,7 +222,10 @@ class database:
         Remove node property.
         """
         id_value = str(id_value)
-        query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) REMOVE n." + property_name
+        query_string = (
+            "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) "
+            "REMOVE n." + property_name
+        )
         
         self.__driver.execute_query(
             query_string,
@@ -208,7 +240,11 @@ class database:
         """
         id_value_a = str(id_value_a)
         id_value_b = str(id_value_b)
-        query_string = "MATCH (a:" + type_a + " {" + id_type_a + ": '" + id_value_a + "'}) MATCH (b:" + type_b + " {" + id_type_b + ": '" + id_value_b + "'}) MERGE (a)-[:" + relationship_type + "]->(b)"
+        query_string = (
+            "MATCH (a:" + type_a + " {" + id_type_a + ": '" + id_value_a + "'}) "
+            "MATCH (b:" + type_b + " {" + id_type_b + ": '" + id_value_b + "'}) "
+            "MERGE (a)-[:" + relationship_type + "]->(b)"
+        )
 
         self.__driver.execute_query(
             query_string,
@@ -222,7 +258,11 @@ class database:
         """
         id_value = str(id_value)
         id_value_new = str(id_value_new)
-        query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) MERGE (m:" + node_type_new + " {" + id_type_new + ": '" + id_value_new + "'}) SET m = properties(n)"
+        query_string = (
+            "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) "
+            "MERGE (m:" + node_type_new + " {" + id_type_new + ": '" + id_value_new + "'}) "
+            "SET m = properties(n)"
+        )
 
         self.__driver.execute_query(
             query_string,
@@ -235,7 +275,10 @@ class database:
         Lookup individual property value from a neighboring node that is connected by certain relationship
         """
         id_value_a = str(id_value_a)
-        query_string = "MATCH (a:" + type_a + " {" + id_type_a + ": '" + id_value_a + "'}) <- [:" + relationship_type + "] - (b) RETURN b." + property_name + " AS " + property_name
+        query_string = (
+            "MATCH (a:" + type_a + " {" + id_type_a + ": '" + id_value_a + "'}) <- [:" + relationship_type + "] - (b) "
+            "RETURN b." + property_name + " AS " + property_name
+        )
         
         records, summary, keys = self.__driver.execute_query(
             query_string,
@@ -252,7 +295,10 @@ class database:
         Check if node exists with specific node type and property value
         """
         id_value = str(id_value)
-        query_string = "MATCH (a:" + type + " {" + id_type + ": '" + id_value + "'}) RETURN a"
+        query_string = (
+            "MATCH (a:" + type + " {" + id_type + ": '" + id_value + "'}) "
+            "RETURN a"
+        )
         
         records, summary, keys = self.__driver.execute_query(
             query_string,

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -469,33 +469,34 @@ class database:
 
     ### Result
     # Todo: not needing to put id values(bad dupes), accept multiple relationships and accept no relationships
-    def add_result_node(self, result_id_value, project_id_value, analyze_model_id_value, used_analyze_model_id_value, used_dataset_id_value, used_data_model_id_value):
-        """Create Result node with all the connected information."""
-        return_a = self.__add_node(self.__result_type, self.__result_id, result_id_value)
-        return_b = self.__connect_result_to_project(result_id_value, project_id_value)
-        ### search connected Dataset, make a copy of that and connect it
-        project_dataset_id_value = self.__lookup_connected_node_property(self.__project_type, self.__project_id, project_id_value, self.__connect_dataset_project, self.__dataset_id)
-        return_e = self.__copy_node(self.__dataset_type, self.__dataset_id, project_dataset_id_value, self.__used_dataset_type, self.__used_dataset_id, used_dataset_id_value)
-        return_f = self.__connect_used_dataset_to_result(used_dataset_id_value, result_id_value)
+    
+    # def add_result_node(self, result_id_value, project_id_value, analyze_model_id_value, used_analyze_model_id_value, used_dataset_id_value, used_data_model_id_value):
+    #     """Create Result node with all the connected information."""
+    #     return_a = self.__add_node(self.__result_type, self.__result_id, result_id_value)
+    #     return_b = self.__connect_result_to_project(result_id_value, project_id_value)
+    #     ### search connected Dataset, make a copy of that and connect it
+    #     project_dataset_id_value = self.__lookup_connected_node_property(self.__project_type, self.__project_id, project_id_value, self.__connect_dataset_project, self.__dataset_id)
+    #     return_e = self.__copy_node(self.__dataset_type, self.__dataset_id, project_dataset_id_value, self.__used_dataset_type, self.__used_dataset_id, used_dataset_id_value)
+    #     return_f = self.__connect_used_dataset_to_result(used_dataset_id_value, result_id_value)
 
-        ### make a copy of AnalyzeModel and connect it
-        return_c = self.__copy_node(self.__analyze_model_type, self.__analyze_model_id, analyze_model_id_value, self.__used_analyze_model_type, self.__used_analyze_model_id, used_analyze_model_id_value)
-        return_d = self.__connect_used_analyze_model_to_result(used_analyze_model_id_value, result_id_value)
-        ### search connected Dataset, make a copy of that and connect it
-        analyze_model_dataset_id_value = self.__lookup_connected_node_property(self.__analyze_model_type, self.__analyze_model_id, analyze_model_id_value, self.__connect_dataset_analyze_model, self.__dataset_id)
-        return_e = self.__copy_node(self.__dataset_type, self.__dataset_id, analyze_model_dataset_id_value, self.__used_dataset_type, self.__used_dataset_id, 3)
-        return_f = self.__connect_used_dataset_to_used_analyze_model(3, used_analyze_model_id_value)
+    #     ### make a copy of AnalyzeModel and connect it
+    #     return_c = self.__copy_node(self.__analyze_model_type, self.__analyze_model_id, analyze_model_id_value, self.__used_analyze_model_type, self.__used_analyze_model_id, used_analyze_model_id_value)
+    #     return_d = self.__connect_used_analyze_model_to_result(used_analyze_model_id_value, result_id_value)
+    #     ### search connected Dataset, make a copy of that and connect it
+    #     analyze_model_dataset_id_value = self.__lookup_connected_node_property(self.__analyze_model_type, self.__analyze_model_id, analyze_model_id_value, self.__connect_dataset_analyze_model, self.__dataset_id)
+    #     return_e = self.__copy_node(self.__dataset_type, self.__dataset_id, analyze_model_dataset_id_value, self.__used_dataset_type, self.__used_dataset_id, 3)
+    #     return_f = self.__connect_used_dataset_to_used_analyze_model(3, used_analyze_model_id_value)
 
-        ### search connected DataModel, make a copy of that and connect it
-        project_data_model_id_value = self.__lookup_connected_node_property(self.__project_type, self.__project_id, project_id_value, self.__connect_data_model_project, self.__data_model_id)
-        return_e = self.__copy_node(self.__data_model_type, self.__data_model_id, project_data_model_id_value, self.__used_data_model_type, self.__used_data_model_id, used_data_model_id_value)
-        return_f = self.__connect_used_data_model_to_result(used_data_model_id_value, result_id_value)
-        ### search connected Dataset, make a copy of that and connect it
-        data_model_dataset_id_value = self.__lookup_connected_node_property(self.__data_model_type, self.__data_model_id, project_data_model_id_value, self.__connect_dataset_data_model, self.__dataset_id)
-        return_g = self.__copy_node(self.__dataset_type, self.__dataset_id, data_model_dataset_id_value, self.__used_dataset_type, self.__used_dataset_id, 2)
-        return_h = self.__connect_used_dataset_to_used_data_model(2, used_data_model_id_value)
+    #     ### search connected DataModel, make a copy of that and connect it
+    #     project_data_model_id_value = self.__lookup_connected_node_property(self.__project_type, self.__project_id, project_id_value, self.__connect_data_model_project, self.__data_model_id)
+    #     return_e = self.__copy_node(self.__data_model_type, self.__data_model_id, project_data_model_id_value, self.__used_data_model_type, self.__used_data_model_id, used_data_model_id_value)
+    #     return_f = self.__connect_used_data_model_to_result(used_data_model_id_value, result_id_value)
+    #     ### search connected Dataset, make a copy of that and connect it
+    #     data_model_dataset_id_value = self.__lookup_connected_node_property(self.__data_model_type, self.__data_model_id, project_data_model_id_value, self.__connect_dataset_data_model, self.__dataset_id)
+    #     return_g = self.__copy_node(self.__dataset_type, self.__dataset_id, data_model_dataset_id_value, self.__used_dataset_type, self.__used_dataset_id, 2)
+    #     return_h = self.__connect_used_dataset_to_used_data_model(2, used_data_model_id_value)
 
-        return "result node created"
+    #     return "result node created"
 
     def set_result_property(self, id_value, property_name, new_data):
         """Set Result property. Creates/overwrites current data.""" 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -207,6 +207,30 @@ def db_delete_settings():
 
 
 """
+User settings functions
+"""
+# Create new Settings-node named "Base". Avoids duplicates.
+def db_add_user_settings_node():
+    return db_add_node('UserSettings', settings_node_name)
+
+# Modify Settings (Base) properties. Replaces specific property with new data.
+def db_modify_user_settings_data(property_name, new_data):
+    return db_modify_node_data('UserSettings', settings_node_name, property_name, new_data)
+
+# Removes specific Settings property data (and property).
+def db_delete_user_settings_data(property_name):
+    return db_delete_property('UserSettings', settings_node_name, property_name)
+
+# Return data of specific property from settings (Base)
+def db_lookup_user_settings_data(property_name):
+    return db_lookup_node_property('UserSettings', settings_node_name, property_name)
+
+# Deletes global settings with all it's related content.
+def db_delete_user_settings():
+    return db_delete_node('UserSettings', settings_node_name)
+
+
+"""
 Subject area functions
 """
 # Create new SubjectArea-node with specific name. Avoids duplicates.

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -242,6 +242,25 @@ class database:
             return next(iter(records)).data()[property_name]
         except:
             return "ERROR: Property not found"
+    
+    def __does_node_exist(self, type, id_type, id_value):
+        """return true/false
+        Check if node exists with specific node type and property value
+        """
+        id_value = str(id_value)
+        query_string = "MATCH (a:" + type + " {" + id_type + ": '" + id_value + "'}) RETURN a"
+        
+        records, summary, keys = self.__driver.execute_query(
+            query_string,
+            database_= self.__name,
+        )
+
+        print(records)
+
+        if not records:
+            return False
+        else:
+            return True
 
 
     

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -7,63 +7,63 @@ class database:
         """Start up database connection.
         Setup types and identifier names according to database design.
         """
-        self.driver = GraphDatabase.driver(os.getenv('NEO4J_URL'), auth=(os.getenv('NEO4J_USER'), os.getenv('NEO4J_PASSWORD')))
-        self.name = 'neo4j'     # database name
+        self.__driver = GraphDatabase.driver(os.getenv('NEO4J_URL'), auth=(os.getenv('NEO4J_USER'), os.getenv('NEO4J_PASSWORD')))
+        self.__name = 'neo4j'     # database name
 
-        self.global_settings_type = 'Settings'
-        self.global_settings_id = 'name'
-        self.global_settings_id_value = 'Global'
+        self.__global_settings_type = 'Settings'
+        self.__global_settings_id = 'name'
+        self.__global_settings_id_value = 'Global'
 
-        self.user_settings_type = 'UserSettings'
-        self.user_settings_id = 'user_name'
+        self.__user_settings_type = 'UserSettings'
+        self.__user_settings_id = 'user_name'
         
-        self.dataset_type = 'Dataset'
-        self.dataset_id = 'id'
+        self.__dataset_type = 'Dataset'
+        self.__dataset_id = 'id'
         
-        self.data_model_type = 'DataModel'
-        self.data_model_id = 'id'
+        self.__data_model_type = 'DataModel'
+        self.__data_model_id = 'id'
         
-        self.analyze_model_type = 'AnalyzeModel'
-        self.analyze_model_id = 'id'
+        self.__analyze_model_type = 'AnalyzeModel'
+        self.__analyze_model_id = 'id'
         
-        self.project_type = 'Project'
-        self.project_id = 'id'
-        self.project_exclusion = ['FAVORITED_IN'] # exclusion for deletion
+        self.__project_type = 'Project'
+        self.__project_id = 'id'
+        self.__project_exclusion = ['FAVORITED_IN'] # exclusion for deletion
         
-        self.result_type = 'Result'
-        self.result_id = 'id'
+        self.__result_type = 'Result'
+        self.__result_id = 'id'
         
-        self.used_dataset_type = 'UsedDataSet'
-        self.used_dataset_id = 'id'
+        self.__used_dataset_type = 'UsedDataSet'
+        self.__used_dataset_id = 'id'
 
-        self.used_data_model_type = 'UsedDataModel'
-        self.used_data_model_id = 'id'
+        self.__used_data_model_type = 'UsedDataModel'
+        self.__used_data_model_id = 'id'
 
-        self.used_analyze_model_type = 'UsedAnalyzeModel'
-        self.used_analyze_model_id = 'id'
+        self.__used_analyze_model_type = 'UsedAnalyzeModel'
+        self.__used_analyze_model_id = 'id'
         
 
-        self.connect_dataset_data_model = 'USED_FOR_TRAINING'
-        self.connect_dataset_analyze_model = 'USED_FOR_TRAINING'
+        self.__connect_dataset_data_model = 'USED_FOR_TRAINING'
+        self.__connect_dataset_analyze_model = 'USED_FOR_TRAINING'
 
-        self.connect_dataset_project = 'ANALYZED_IN'
-        self.connect_result_project = 'BELONGS_TO'
-        self.connect_data_model_project = 'ACTIVE_IN'
+        self.__connect_dataset_project = 'ANALYZED_IN'
+        self.__connect_result_project = 'BELONGS_TO'
+        self.__connect_data_model_project = 'ACTIVE_IN'
 
-        self.connect_used_analyze_model_result = 'USED_IN_ANALYSIS'
-        self.connect_used_data_model_result = 'USED_IN_ANALYSIS'
-        self.connect_used_dataset_result = 'USED_IN_ANALYSIS'
-        self.connect_used_dataset_used_data_model = 'USED_FOR_TRAINING'
-        self.connect_used_dataset_used_analyze_model = 'USED_FOR_TRAINING'
+        self.__connect_used_analyze_model_result = 'USED_IN_ANALYSIS'
+        self.__connect_used_data_model_result = 'USED_IN_ANALYSIS'
+        self.__connect_used_dataset_result = 'USED_IN_ANALYSIS'
+        self.__connect_used_dataset_used_data_model = 'USED_FOR_TRAINING'
+        self.__connect_used_dataset_used_analyze_model = 'USED_FOR_TRAINING'
 
 
     def debug_clear_all(self):
         """return useful string message
         DEBUG: Clear the whole database
         """
-        self.driver.execute_query(
+        self.__driver.execute_query(
             "MATCH (n) DETACH DELETE n",
-            database_= self.name,
+            database_= self.__name,
         )
         return "Database cleared"
 
@@ -72,9 +72,9 @@ class database:
         """return useful string message
         DEBUG: Print the whole database in console.
         """
-        records, summary, keys = self.driver.execute_query(
+        records, summary, keys = self.__driver.execute_query(
             "MATCH (n) RETURN n",
-            database_= self.name,
+            database_= self.__name,
         )
         
         for record in records:
@@ -90,10 +90,10 @@ class database:
         id_value = str(id_value)
         query_string = "MERGE (n:" + type + " {" + id_type + ": $value})"
 
-        self.driver.execute_query(
+        self.__driver.execute_query(
             query_string,
             value = id_value,
-            database_= self.name,
+            database_= self.__name,
         )
         return "Added node: " + type + "." + id_type + "(" + id_value + ")"
             
@@ -105,10 +105,10 @@ class database:
         id_value = str(id_value)
         query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) SET n." + property_name + " = $old_data"
 
-        self.driver.execute_query(
+        self.__driver.execute_query(
             query_string,
             old_data = new_data,
-            database_= self.name,
+            database_= self.__name,
         )
         return "Modified data: " + type + "("+ id_value +")."+ property_name
     
@@ -120,9 +120,9 @@ class database:
         id_value = str(id_value)
         query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) RETURN n"
         
-        records, summary, keys = self.driver.execute_query(
+        records, summary, keys = self.__driver.execute_query(
             query_string,
-            database_= self.name,
+            database_= self.__name,
         )
 
         try:
@@ -138,9 +138,9 @@ class database:
         id_value = str(id_value)
         query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) RETURN n." + property_name + " AS " + property_name
         
-        records, summary, keys = self.driver.execute_query(
+        records, summary, keys = self.__driver.execute_query(
             query_string,
-            database_= self.name,
+            database_= self.__name,
         )
         
         try:
@@ -164,9 +164,9 @@ class database:
         else:
             return "ERROR: exclude_relationships was something else than None, string or list of string"
         
-        self.driver.execute_query(
+        self.__driver.execute_query(
             query_string,
-            database_= self.name,
+            database_= self.__name,
         )
         return type + "(" + id_value + ") deleted with connections"
 
@@ -177,9 +177,9 @@ class database:
         id_value = str(id_value)
         query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) DETACH DELETE n"
         
-        self.driver.execute_query(
+        self.__driver.execute_query(
             query_string,
-            database_= self.name,
+            database_= self.__name,
         )
         return type + "(" + id_value + ") deleted"
     
@@ -191,9 +191,9 @@ class database:
         id_value = str(id_value)
         query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) REMOVE n." + property_name
         
-        self.driver.execute_query(
+        self.__driver.execute_query(
             query_string,
-            database_= self.name,
+            database_= self.__name,
         )
         return "Removed: " + type + "(" + id_value + ")." + property_name
     
@@ -206,9 +206,9 @@ class database:
         id_value_b = str(id_value_b)
         query_string = "MATCH (a:" + type_a + " {" + id_type_a + ": '" + id_value_a + "'}) MATCH (b:" + type_b + " {" + id_type_b + ": '" + id_value_b + "'}) MERGE (a)-[:" + relationship_type + "]->(b)"
 
-        self.driver.execute_query(
+        self.__driver.execute_query(
             query_string,
-            database_= self.name,
+            database_= self.__name,
         )
         return "Connected: " + type_a + "(" + id_value_a + ")-[" + relationship_type + "]>" + type_b + "(" + id_value_b + ")"
     
@@ -220,9 +220,9 @@ class database:
         id_value_new = str(id_value_new)
         query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) MERGE (m:" + node_type_new + " {" + id_type_new + ": '" + id_value_new + "'}) SET m = properties(n)"
 
-        self.driver.execute_query(
+        self.__driver.execute_query(
             query_string,
-            database_= self.name,
+            database_= self.__name,
         )
         return "Copied " + type + "(" + id_value + ") to " + node_type_new + "(" + id_value_new + ")"
     
@@ -233,9 +233,9 @@ class database:
         id_value_a = str(id_value_a)
         query_string = "MATCH (a:" + type_a + " {" + id_type_a + ": '" + id_value_a + "'}) <- [:" + relationship_type + "] - (b) RETURN b." + property_name + " AS " + property_name
         
-        records, summary, keys = self.driver.execute_query(
+        records, summary, keys = self.__driver.execute_query(
             query_string,
-            database_= self.name,
+            database_= self.__name,
         )
         
         try:
@@ -248,205 +248,205 @@ class database:
     ### Connections
     def connect_dataset_to_data_model(self, dataset_id_value, data_model_id_value):
         """Connect Dataset to DataModel"""
-        return self.__connect_with_relationship(self.dataset_type, self.dataset_id, dataset_id_value, self.data_model_type, self.data_model_id, data_model_id_value, self.connect_dataset_data_model)
+        return self.__connect_with_relationship(self.__dataset_type, self.__dataset_id, dataset_id_value, self.__data_model_type, self.__data_model_id, data_model_id_value, self.__connect_dataset_data_model)
     
 
     def connect_dataset_to_analyze_model(self, dataset_id_value, analyze_model_id_value):
         """Connect Dataset to AnalyzeModel"""
-        return self.__connect_with_relationship(self.dataset_type, self.dataset_id, dataset_id_value, self.analyze_model_type, self.analyze_model_id, analyze_model_id_value, self.connect_dataset_analyze_model)
+        return self.__connect_with_relationship(self.__dataset_type, self.__dataset_id, dataset_id_value, self.__analyze_model_type, self.__analyze_model_id, analyze_model_id_value, self.__connect_dataset_analyze_model)
     
 
     def connect_data_model_to_project(self, data_model_id_value, project_id_value):
         """Connect DataModel to Project"""
-        return self.__connect_with_relationship(self.data_model_type, self.data_model_id, data_model_id_value, self.project_type, self.project_id, project_id_value, self.connect_data_model_project)
+        return self.__connect_with_relationship(self.__data_model_type, self.__data_model_id, data_model_id_value, self.__project_type, self.__project_id, project_id_value, self.__connect_data_model_project)
 
 
     def connect_dataset_to_project(self, dataset_id_value, project_id_value):
         """Connect Dataset to Project"""
-        return self.__connect_with_relationship(self.dataset_type, self.dataset_id, dataset_id_value, self.project_type, self.project_id, project_id_value, self.connect_dataset_project)
+        return self.__connect_with_relationship(self.__dataset_type, self.__dataset_id, dataset_id_value, self.__project_type, self.__project_id, project_id_value, self.__connect_dataset_project)
 
 
     def __connect_result_to_project(self, result_id_value, project_id_value):
         """Connect Result to Project"""
-        return self.__connect_with_relationship(self.result_type, self.result_id, result_id_value, self.project_type, self.project_id, project_id_value, self.connect_result_project)
+        return self.__connect_with_relationship(self.__result_type, self.__result_id, result_id_value, self.__project_type, self.__project_id, project_id_value, self.__connect_result_project)
     
 
     def __connect_used_dataset_to_result(self, used_dataset_id_value, result_id_value):
         """Connect UsedDataset to Result"""
-        return self.__connect_with_relationship(self.used_dataset_type, self.used_dataset_id, used_dataset_id_value, self.result_type, self.result_id, result_id_value, self.connect_used_dataset_result)
+        return self.__connect_with_relationship(self.__used_dataset_type, self.__used_dataset_id, used_dataset_id_value, self.__result_type, self.__result_id, result_id_value, self.__connect_used_dataset_result)
 
 
     def __connect_used_analyze_model_to_result(self, used_analyze_model_id_value, result_id_value):
         """Connect UsedAnalyzeModel to Result"""
-        return self.__connect_with_relationship(self.used_analyze_model_type, self.used_analyze_model_id, used_analyze_model_id_value, self.result_type, self.result_id, result_id_value, self.connect_used_analyze_model_result)
+        return self.__connect_with_relationship(self.__used_analyze_model_type, self.__used_analyze_model_id, used_analyze_model_id_value, self.__result_type, self.__result_id, result_id_value, self.__connect_used_analyze_model_result)
     
 
     def __connect_used_data_model_to_result(self, used_data_model_id_value, result_id_value):
         """Connect UsedDataModel to Result"""
-        return self.__connect_with_relationship(self.used_data_model_type, self.used_data_model_id, used_data_model_id_value, self.result_type, self.result_id, result_id_value, self.connect_used_data_model_result)
+        return self.__connect_with_relationship(self.__used_data_model_type, self.__used_data_model_id, used_data_model_id_value, self.__result_type, self.__result_id, result_id_value, self.__connect_used_data_model_result)
     
 
     def __connect_used_dataset_to_used_data_model(self, used_dataset_id_value, used_data_model_id_value):
         """Connect UsedDataset to UsedDataModel"""
-        return self.__connect_with_relationship(self.used_dataset_type, self.used_dataset_id, used_dataset_id_value, self.used_data_model_type, self.used_data_model_id, used_data_model_id_value, self.connect_used_dataset_used_data_model)
+        return self.__connect_with_relationship(self.__used_dataset_type, self.__used_dataset_id, used_dataset_id_value, self.__used_data_model_type, self.__used_data_model_id, used_data_model_id_value, self.__connect_used_dataset_used_data_model)
     
 
     def __connect_used_dataset_to_used_analyze_model(self, used_dataset_id_value, used_analyze_model_id_value):
         """Connect UsedDataset to UsedAnalyzeModel"""
-        return self.__connect_with_relationship(self.used_dataset_type, self.used_dataset_id, used_dataset_id_value, self.used_analyze_model_type, self.used_analyze_model_id, used_analyze_model_id_value, self.connect_used_dataset_used_analyze_model)
+        return self.__connect_with_relationship(self.__used_dataset_type, self.__used_dataset_id, used_dataset_id_value, self.__used_analyze_model_type, self.__used_analyze_model_id, used_analyze_model_id_value, self.__connect_used_dataset_used_analyze_model)
 
     
     ### Global settings
     def add_global_settings_node(self):
         """Create global settings node"""        
-        return self.__add_node(self.global_settings_type, self.global_settings_id, self.global_settings_id_value)
+        return self.__add_node(self.__global_settings_type, self.__global_settings_id, self.__global_settings_id_value)
 
 
     def set_global_settings_property(self, property_name, new_data):
         """Set global settings property data.""" 
-        return self.__set_node_property(self.global_settings_type, self.global_settings_id, self.global_settings_id_value, property_name, new_data)
+        return self.__set_node_property(self.__global_settings_type, self.__global_settings_id, self.__global_settings_id_value, property_name, new_data)
     
         
     def remove_global_settings_property(self, property_name):
         """Removes specific Settings property data (and property)""" 
-        return self.__remove_property(self.global_settings_type, self.global_settings_id, self.global_settings_id_value, property_name)
+        return self.__remove_property(self.__global_settings_type, self.__global_settings_id, self.__global_settings_id_value, property_name)
 
 
     def lookup_global_settings_property(self, property_name):
         """Return data of specific property from settings""" 
-        return self.__lookup_node_property(self.global_settings_type, self.global_settings_id, self.global_settings_id_value, property_name)
+        return self.__lookup_node_property(self.__global_settings_type, self.__global_settings_id, self.__global_settings_id_value, property_name)
     
 
     def delete_global_settings(self):
         """Delete global settings node""" 
-        return self.__delete_node(self.global_settings_type, self.global_settings_id, self.global_settings_id_value)
+        return self.__delete_node(self.__global_settings_type, self.__global_settings_id, self.__global_settings_id_value)
     
 
     ### User settings
     def add_user_settings_node(self, id_value):
         """Create user settings node"""        
-        return self.__add_node(self.user_settings_type, self.user_settings_id, id_value)
+        return self.__add_node(self.__user_settings_type, self.__user_settings_id, id_value)
 
 
     def set_user_settings_property(self, id_value, property_name, new_data):
         """Set user settings property. Creates/overwrites current data.""" 
-        return self.__set_node_property(self.user_settings_type, self.user_settings_id, id_value, property_name, new_data)
+        return self.__set_node_property(self.__user_settings_type, self.__user_settings_id, id_value, property_name, new_data)
     
         
     def remove_user_settings_property(self, id_value, property_name):
         """Removes specific Settings property data (and property)""" 
-        return self.__remove_property(self.user_settings_type, self.user_settings_id, id_value, property_name)
+        return self.__remove_property(self.__user_settings_type, self.__user_settings_id, id_value, property_name)
 
 
     def lookup_user_settings_property(self, id_value, property_name):
         """Return data of specific property from settings""" 
-        return self.__lookup_node_property(self.user_settings_type, self.user_settings_id, id_value, property_name)
+        return self.__lookup_node_property(self.__user_settings_type, self.__user_settings_id, id_value, property_name)
     
 
     def delete_user_settings(self, id_value):
         """Delete global settings node""" 
-        return self.__delete_node(self.user_settings_type, self.user_settings_id, id_value)
+        return self.__delete_node(self.__user_settings_type, self.__user_settings_id, id_value)
     
 
     ### Project
     def add_project_node(self, id_value):
         """Create Project node. Avoids duplicates."""        
-        return self.__add_node(self.project_type, self.project_id, id_value)
+        return self.__add_node(self.__project_type, self.__project_id, id_value)
 
 
     def set_project_property(self, id_value, property_name, new_data):
         """Set Project property. Creates/overwrites current data.""" 
-        return self.__set_node_property(self.project_type, self.project_id, id_value, property_name, new_data)
+        return self.__set_node_property(self.__project_type, self.__project_id, id_value, property_name, new_data)
     
         
     def remove_project_property(self, id_value, property_name):
         """Removes specific Project property data (and property)""" 
-        return self.__remove_property(self.project_type, self.project_id, id_value, property_name)
+        return self.__remove_property(self.__project_type, self.__project_id, id_value, property_name)
 
 
     def lookup_project_property(self, id_value, property_name):
         """Return data of specific property from Project""" 
-        return self.__lookup_node_property(self.project_type, self.project_id, id_value, property_name)
+        return self.__lookup_node_property(self.__project_type, self.__project_id, id_value, property_name)
     
 
     def delete_project(self, id_value):
         """Delete project node""" 
-        return self.__delete_node_with_connections(self.project_type, self.project_id, id_value, self.project_exclusion)
+        return self.__delete_node_with_connections(self.__project_type, self.__project_id, id_value, self.__project_exclusion)
     
 
 
     ### Dataset
     def add_dataset_node(self, id_value):
         """Create Dataset node. Avoids duplicates."""        
-        return self.__add_node(self.dataset_type, self.dataset_id, id_value)
+        return self.__add_node(self.__dataset_type, self.__dataset_id, id_value)
 
 
     def set_dataset_property(self, id_value, property_name, new_data):
         """Set Dataset property. Creates/overwrites current data.""" 
-        return self.__set_node_property(self.dataset_type, self.dataset_id, id_value, property_name, new_data)
+        return self.__set_node_property(self.__dataset_type, self.__dataset_id, id_value, property_name, new_data)
     
         
     def lookup_dataset_property(self, id_value, property_name):
         """Return data of specific property from Dataset""" 
-        return self.__lookup_node_property(self.dataset_type, self.dataset_id, id_value, property_name)
+        return self.__lookup_node_property(self.__dataset_type, self.__dataset_id, id_value, property_name)
     
 
     def delete_dataset(self, id_value):
         """Delete Dataset node"""
-        return self.__delete_node(self.dataset_type, self.dataset_id, id_value)
+        return self.__delete_node(self.__dataset_type, self.__dataset_id, id_value)
     
 
     ### DataModel
     def add_data_model_node(self, id_value):
         """Create DataModel node. Avoids duplicates."""
-        return self.__add_node(self.data_model_type, self.data_model_id, id_value)
+        return self.__add_node(self.__data_model_type, self.__data_model_id, id_value)
 
 
     def set_data_model_property(self, id_value, property_name, new_data):
         """Set DataModel property. Creates/overwrites current data.""" 
-        return self.__set_node_property(self.data_model_type, self.data_model_id, id_value, property_name, new_data)
+        return self.__set_node_property(self.__data_model_type, self.__data_model_id, id_value, property_name, new_data)
     
         
     def remove_data_model_property(self, id_value, property_name):
         """Removes specific DataModel property data (and property)""" 
-        return self.__remove_property(self.data_model_type, self.data_model_id, id_value, property_name)
+        return self.__remove_property(self.__data_model_type, self.__data_model_id, id_value, property_name)
 
 
     def lookup_data_model_property(self, id_value, property_name):
         """Return data of specific property from DataModel""" 
-        return self.__lookup_node_property(self.data_model_type, self.data_model_id, id_value, property_name)
+        return self.__lookup_node_property(self.__data_model_type, self.__data_model_id, id_value, property_name)
     
 
     def delete_data_model(self, id_value):
         """Delete DataModel node""" 
-        return self.__delete_node_with_connections(self.data_model_type, self.data_model_id, id_value)
+        return self.__delete_node_with_connections(self.__data_model_type, self.__data_model_id, id_value)
     
 
 
         ### AnalyzeModel
     def add_analyze_model_node(self, id_value):
         """Create AnalyzeModel node. Avoids duplicates."""
-        return self.__add_node(self.analyze_model_type, self.analyze_model_id, id_value)
+        return self.__add_node(self.__analyze_model_type, self.__analyze_model_id, id_value)
 
 
     def set_analyze_model_property(self, id_value, property_name, new_data):
         """Set AnalyzeModel property. Creates/overwrites current data.""" 
-        return self.__set_node_property(self.analyze_model_type, self.analyze_model_id, id_value, property_name, new_data)
+        return self.__set_node_property(self.__analyze_model_type, self.__analyze_model_id, id_value, property_name, new_data)
     
         
     def remove_analyze_model_property(self, id_value, property_name):
         """Removes specific AnalyzeModel property data (and property)""" 
-        return self.__remove_property(self.analyze_model_type, self.analyze_model_id, id_value, property_name)
+        return self.__remove_property(self.__analyze_model_type, self.__analyze_model_id, id_value, property_name)
 
 
     def lookup_analyze_model_property(self, id_value, property_name):
         """Return data of specific property from AnalyzeModel""" 
-        return self.__lookup_node_property(self.analyze_model_type, self.analyze_model_id, id_value, property_name)
+        return self.__lookup_node_property(self.__analyze_model_type, self.__analyze_model_id, id_value, property_name)
     
 
     def delete_analyze_model(self, id_value):
         """Delete AnalyzeModel node""" 
-        return self.__delete_node_with_connections(self.analyze_model_type, self.analyze_model_id, id_value)
+        return self.__delete_node_with_connections(self.__analyze_model_type, self.__analyze_model_id, id_value)
 
    
 
@@ -454,42 +454,42 @@ class database:
     # Todo: not needing to put id values(bad dupes), accept multiple relationships and accept no relationships
     def add_result_node(self, result_id_value, project_id_value, analyze_model_id_value, used_analyze_model_id_value, used_dataset_id_value, used_data_model_id_value):
         """Create Result node with all the connected information."""
-        return_a = self.__add_node(self.result_type, self.result_id, result_id_value)
+        return_a = self.__add_node(self.__result_type, self.__result_id, result_id_value)
         return_b = self.__connect_result_to_project(result_id_value, project_id_value)
         ### search connected Dataset, make a copy of that and connect it
-        project_dataset_id_value = self.__lookup_connected_node_property(self.project_type, self.project_id, project_id_value, self.connect_dataset_project, self.dataset_id)
-        return_e = self.__copy_node(self.dataset_type, self.dataset_id, project_dataset_id_value, self.used_dataset_type, self.used_dataset_id, used_dataset_id_value)
+        project_dataset_id_value = self.__lookup_connected_node_property(self.__project_type, self.__project_id, project_id_value, self.__connect_dataset_project, self.__dataset_id)
+        return_e = self.__copy_node(self.__dataset_type, self.__dataset_id, project_dataset_id_value, self.__used_dataset_type, self.__used_dataset_id, used_dataset_id_value)
         return_f = self.__connect_used_dataset_to_result(used_dataset_id_value, result_id_value)
 
         ### make a copy of AnalyzeModel and connect it
-        return_c = self.__copy_node(self.analyze_model_type, self.analyze_model_id, analyze_model_id_value, self.used_analyze_model_type, self.used_analyze_model_id, used_analyze_model_id_value)
+        return_c = self.__copy_node(self.__analyze_model_type, self.__analyze_model_id, analyze_model_id_value, self.__used_analyze_model_type, self.__used_analyze_model_id, used_analyze_model_id_value)
         return_d = self.__connect_used_analyze_model_to_result(used_analyze_model_id_value, result_id_value)
         ### search connected Dataset, make a copy of that and connect it
-        analyze_model_dataset_id_value = self.__lookup_connected_node_property(self.analyze_model_type, self.analyze_model_id, analyze_model_id_value, self.connect_dataset_analyze_model, self.dataset_id)
-        return_e = self.__copy_node(self.dataset_type, self.dataset_id, analyze_model_dataset_id_value, self.used_dataset_type, self.used_dataset_id, 3)
+        analyze_model_dataset_id_value = self.__lookup_connected_node_property(self.__analyze_model_type, self.__analyze_model_id, analyze_model_id_value, self.__connect_dataset_analyze_model, self.__dataset_id)
+        return_e = self.__copy_node(self.__dataset_type, self.__dataset_id, analyze_model_dataset_id_value, self.__used_dataset_type, self.__used_dataset_id, 3)
         return_f = self.__connect_used_dataset_to_used_analyze_model(3, used_analyze_model_id_value)
 
         ### search connected DataModel, make a copy of that and connect it
-        project_data_model_id_value = self.__lookup_connected_node_property(self.project_type, self.project_id, project_id_value, self.connect_data_model_project, self.data_model_id)
-        return_e = self.__copy_node(self.data_model_type, self.data_model_id, project_data_model_id_value, self.used_data_model_type, self.used_data_model_id, used_data_model_id_value)
+        project_data_model_id_value = self.__lookup_connected_node_property(self.__project_type, self.__project_id, project_id_value, self.__connect_data_model_project, self.__data_model_id)
+        return_e = self.__copy_node(self.__data_model_type, self.__data_model_id, project_data_model_id_value, self.__used_data_model_type, self.__used_data_model_id, used_data_model_id_value)
         return_f = self.__connect_used_data_model_to_result(used_data_model_id_value, result_id_value)
         ### search connected Dataset, make a copy of that and connect it
-        data_model_dataset_id_value = self.__lookup_connected_node_property(self.data_model_type, self.data_model_id, project_data_model_id_value, self.connect_dataset_data_model, self.dataset_id)
-        return_g = self.__copy_node(self.dataset_type, self.dataset_id, data_model_dataset_id_value, self.used_dataset_type, self.used_dataset_id, 2)
+        data_model_dataset_id_value = self.__lookup_connected_node_property(self.__data_model_type, self.__data_model_id, project_data_model_id_value, self.__connect_dataset_data_model, self.__dataset_id)
+        return_g = self.__copy_node(self.__dataset_type, self.__dataset_id, data_model_dataset_id_value, self.__used_dataset_type, self.__used_dataset_id, 2)
         return_h = self.__connect_used_dataset_to_used_data_model(2, used_data_model_id_value)
 
         return "result node created"
 
     def set_result_property(self, id_value, property_name, new_data):
         """Set Result property. Creates/overwrites current data.""" 
-        return self.__set_node_property(self.result_type, self.result_id, id_value, property_name, new_data)
+        return self.__set_node_property(self.__result_type, self.__result_id, id_value, property_name, new_data)
     
     def lookup_result_property(self, id_value, property_name):
         """Return data of specific property from Result""" 
-        return self.__lookup_node_property(self.result_type, self.result_id, id_value, property_name)
+        return self.__lookup_node_property(self.__result_type, self.__result_id, id_value, property_name)
     
     def delete_result(self, id_value):
         """Delete Result node""" 
-        return self.__delete_node_with_connections(self.result_type, self.result_id, id_value)
+        return self.__delete_node_with_connections(self.__result_type, self.__result_id, id_value)
 
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -229,27 +229,27 @@ def db_delete_user_settings(user_name):
     return db_delete_node('UserSettings', user_name)
 
 """
-Subject area functions
+Project functions
 """
-# Create new SubjectArea-node with specific name. Avoids duplicates.
-def db_add_subject_area_node(node_name):
-    return db_add_node('SubjectArea', node_name)
+# Create new Project-node with specific name. Avoids duplicates.
+def db_add_project_node(node_name):
+    return db_add_node('Project', node_name)
 
-# Modify SubjectArea-node's properties. Replaces specific property with new data.
-def db_modify_subject_area_data(node_name, property_name, new_data):
-    return db_modify_node_data('SubjectArea', node_name, property_name, new_data)
+# Modify Project-node's properties. Replaces specific property with new data.
+def db_modify_project_data(node_name, property_name, new_data):
+    return db_modify_node_data('Project', node_name, property_name, new_data)
 
-# Removes specific subject area property data (and property).
-def db_delete_subject_area_data(node_name, property_name):
-    return db_delete_property('SubjectArea', node_name, property_name)
+# Removes specific Project property data (and property).
+def db_delete_project_data(node_name, property_name):
+    return db_delete_property('Project', node_name, property_name)
 
-# Return data of specific property from SubjectArea-node
-def db_lookup_subject_area_data(node_name, property_name):
-    return db_lookup_node_property('SubjectArea', node_name, property_name)
+# Return data of specific property from Project-node
+def db_lookup_project_data(node_name, property_name):
+    return db_lookup_node_property('Project', node_name, property_name)
 
-# Deletes specific subject area with all it's related content.
-def db_delete_subject_area(node_name):
-    return db_delete_node_with_connections('SubjectArea', node_name)
+# Deletes specific Project with all it's related content.
+def db_delete_project(node_name):
+    return db_delete_node_with_connections('Project', node_name)
 
 """
 Result functions
@@ -342,9 +342,9 @@ def db_delete_dataset(node_id):
 """
 Connection functions
 """
-# Connect from Dataset node to subject area node
-def db_connect_dataset_to_subject_area(dataset_node_id, subject_area_node_name):
-    return db_connect_with_relationship('Dataset', dataset_node_id, 'SubjectArea', subject_area_node_name, 'ANALYZED_IN')
+# Connect from Dataset node to project node
+def db_connect_dataset_to_project(dataset_node_id, project_node_name):
+    return db_connect_with_relationship('Dataset', dataset_node_id, 'Project', project_node_name, 'ANALYZED_IN')
 
 # Connect from Dataset node to DataModel node
 def db_connect_dataset_to_data_model(dataset_node_id, model_node_name):

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -234,3 +234,26 @@ def db_lookup_model_data(node_name, property_name):
 # Deletes specific Model with all it's related content.
 def db_delete_model(node_name):
     return db_delete_node_with_connections('Model', node_name)
+
+"""
+Dataset functions
+"""
+# Create new Dataset-node with specific name. Avoids duplicates.
+def db_add_dataset_node(node_name):
+    return db_add_node('Dataset', node_name)
+
+# Modify Dataset-node's properties. Replaces specific property with new data.
+def db_modify_dataset_data(node_name, property_name, new_data):
+    return db_modify_node_data('Dataset', node_name, property_name, new_data)
+
+# Removes specific Dataset property data (and property).
+def db_delete_dataset_data(node_name, property_name):
+    return db_delete_property('Dataset', node_name, property_name)
+
+# Return data of specific property from Dataset-node
+def db_lookup_dataset_data(node_name, property_name):
+    return db_lookup_node_property('Dataset', node_name, property_name)
+
+# Deletes specific Dataset with all it's related content.
+def db_delete_dataset(node_name):
+    return db_delete_node('Dataset', node_name)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -79,9 +79,9 @@ class database:
         return "Added node: " + type + "." + id_type + "(" + id_value + ")"
             
 
-    def __modify_node_data(self, type, id_type, id_value, property_name, new_data):
+    def __set_node_property(self, type, id_type, id_value, property_name, new_data):
         """return useful string message
-        Replaces specific node property with new data.
+        Set specific node property with new data.
         """
         query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) SET n." + property_name + " = $old_data"
 
@@ -157,9 +157,9 @@ class database:
         return type + "(" + id_value + ") deleted"
     
 
-    def __delete_property(self, type, id_type, id_value, property_name):
+    def __remove_property(self, type, id_type, id_value, property_name):
         """return useful string message
-        Delete node property.
+        Remove node property.
         """
         query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) REMOVE n." + property_name
         
@@ -167,7 +167,7 @@ class database:
             query_string,
             database_= self.name,
         )
-        return "Deleted: " + type + "(" + id_value + ")." + property_name
+        return "Removed: " + type + "(" + id_value + ")." + property_name
     
 
     def __connect_with_relationship(self, type_a, id_type_a, id_value_a, type_b, id_type_b, id_value_b, relationship_type):
@@ -194,20 +194,20 @@ class database:
         )
         return "Copied " + type + "(" + id_value + ") to " + node_type_new + "(" + id_value_new + ")"
     
-
+    ### Global settings
     def add_global_settings_node(self):
         """Create global settings node"""        
         return self.__add_node(self.global_settings_type, self.global_settings_id, self.global_settings_id_value)
 
 
-    def modify_global_settings_property(self, property_name, new_data):
-        """Modify global settings node""" 
-        return self.__modify_node_data(self.global_settings_type, self.global_settings_id, self.global_settings_id_value, property_name, new_data)
+    def set_global_settings_property(self, property_name, new_data):
+        """Set global settings property data.""" 
+        return self.__set_node_property(self.global_settings_type, self.global_settings_id, self.global_settings_id_value, property_name, new_data)
     
         
-    def delete_global_settings_property(self, property_name):
+    def remove_global_settings_property(self, property_name):
         """Removes specific Settings property data (and property)""" 
-        return self.__delete_property(self.global_settings_type, self.global_settings_id, self.global_settings_id_value, property_name)
+        return self.__remove_property(self.global_settings_type, self.global_settings_id, self.global_settings_id_value, property_name)
 
 
     def lookup_global_settings_property(self, property_name):
@@ -218,3 +218,31 @@ class database:
     def delete_global_settings(self):
         """Delete global settings node""" 
         return self.__delete_node(self.global_settings_type, self.global_settings_id, self.global_settings_id_value)
+    
+
+    ### User settings
+    def add_user_settings_node(self, id_value):
+        """Create user settings node"""        
+        return self.__add_node(self.user_settings_type, self.user_settings_id, id_value)
+
+
+    def set_user_settings_property(self, id_value, property_name, new_data):
+        """Set user settings property. Creates/overwrites current data.""" 
+        return self.__set_node_property(self.user_settings_type, self.user_settings_id, id_value, property_name, new_data)
+    
+        
+    def remove_user_settings_property(self, id_value, property_name):
+        """Removes specific Settings property data (and property)""" 
+        return self.__remove_property(self.user_settings_type, self.user_settings_id, id_value, property_name)
+
+
+    def lookup_global_settings_property(self, id_value, property_name):
+        """Return data of specific property from settings""" 
+        return self.__lookup_node_property(self.user_settings_type, self.user_settings_id, id_value, property_name)
+    
+
+    def delete_global_settings(self, id_value):
+        """Delete global settings node""" 
+        return self.__delete_node(self.user_settings_type, self.user_settings_id, id_value)
+    
+

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -269,10 +269,11 @@ todo:
 """
 # Create new Result-node with specific name. Avoids duplicates.
 # Connect it with project
-def db_add_result_node(result_node_id, project_node_name):
+def db_add_result_node(result_node_id, project_node_name, analyze_model_name):
     return_a = db_add_node('Result', result_node_id)
     return_b = db_connect_result_to_project(result_node_id, project_node_name)
-    return return_a + " and " + return_b
+    return_c = db_add_used_analyze_model_node(analyze_model_name, result_node_id)
+    return return_a + " and " + return_b + " and " + return_c
 
 # Modify Result-node's properties. Replaces specific property with new data.
 def db_modify_result_data(node_id, property_name, new_data):

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -56,7 +56,7 @@ def debug_db_show_all():
     )
     
     for record in records:
-        print(record.data())
+        print(record)
 
     return "Whole database printed out in console"
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -374,6 +374,29 @@ class database:
         return self.__delete_node_with_connections(self.project_type, self.project_id, id_value, self.project_exclusion)
     
 
+
+    ### Dataset
+    def add_dataset_node(self, id_value):
+        """Create Dataset node. Avoids duplicates."""        
+        return self.__add_node(self.dataset_type, self.dataset_id, id_value)
+
+
+    def set_dataset_property(self, id_value, property_name, new_data):
+        """Set Dataset property. Creates/overwrites current data.""" 
+        return self.__set_node_property(self.dataset_type, self.dataset_id, id_value, property_name, new_data)
+    
+        
+    def lookup_dataset_property(self, id_value, property_name):
+        """Return data of specific property from Dataset""" 
+        return self.__lookup_node_property(self.dataset_type, self.dataset_id, id_value, property_name)
+    
+
+    def delete_dataset(self, id_value):
+        """Delete Dataset node"""
+        return self.__delete_node(self.dataset_type, self.dataset_id, id_value)
+
+   
+
     ### Result
     # Todo: not needing to put id values(bad dupes), accept multiple relationships and accept no relationships
     def add_result_node(self, result_id_value, project_id_value, analyze_model_id_value, used_analyze_model_id_value, used_dataset_id_value, used_data_model_id_value):

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -420,6 +420,33 @@ class database:
     def delete_data_model(self, id_value):
         """Delete DataModel node""" 
         return self.__delete_node_with_connections(self.data_model_type, self.data_model_id, id_value)
+    
+
+
+        ### AnalyzeModel
+    def add_analyze_model_node(self, id_value):
+        """Create AnalyzeModel node. Avoids duplicates."""
+        return self.__add_node(self.analyze_model_type, self.analyze_model_id, id_value)
+
+
+    def set_analyze_model_property(self, id_value, property_name, new_data):
+        """Set AnalyzeModel property. Creates/overwrites current data.""" 
+        return self.__set_node_property(self.analyze_model_type, self.analyze_model_id, id_value, property_name, new_data)
+    
+        
+    def remove_analyze_model_property(self, id_value, property_name):
+        """Removes specific AnalyzeModel property data (and property)""" 
+        return self.__remove_property(self.analyze_model_type, self.analyze_model_id, id_value, property_name)
+
+
+    def lookup_analyze_model_property(self, id_value, property_name):
+        """Return data of specific property from AnalyzeModel""" 
+        return self.__lookup_node_property(self.analyze_model_type, self.analyze_model_id, id_value, property_name)
+    
+
+    def delete_analyze_model(self, id_value):
+        """Delete AnalyzeModel node""" 
+        return self.__delete_node_with_connections(self.analyze_model_type, self.analyze_model_id, id_value)
 
    
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -264,10 +264,15 @@ def db_delete_project(node_name):
 
 """
 Result functions
+todo:
+- delete all connected UsedInAnalysis nodes too
 """
 # Create new Result-node with specific name. Avoids duplicates.
-def db_add_result_node(node_id):
-    return db_add_node('Result', node_id)
+# Connect it with project
+def db_add_result_node(result_node_id, project_node_name):
+    return_a = db_add_node('Result', result_node_id)
+    return_b = db_connect_result_to_project(result_node_id, project_node_name)
+    return return_a + " and " + return_b
 
 # Modify Result-node's properties. Replaces specific property with new data.
 def db_modify_result_data(node_id, property_name, new_data):
@@ -339,7 +344,7 @@ UsedAnalyzeModel functions
 def db_add_used_analyze_model_node(model_node_name, result_node_name):
     return_a = db_copy_node('AnalyzeModel','UsedAnalyzeModel', 'name', model_node_name)
     return_b = db_connect_dataset_to_analyze_model(model_node_name, result_node_name)
-    return return_a + "and" + return_b
+    return return_a + " and " + return_b
 
 
 db_copy_node
@@ -380,4 +385,8 @@ def db_connect_dataset_to_analyze_model(dataset_node_id, model_node_name):
 # Connect from UsedAnalyzeModel node to Result node
 def db_connect_used_analyze_model_to_result(model_node_name, result_node_name):
     return db_connect_with_relationship('UsedAnalyzeModel', model_node_name, 'Result', result_node_name, 'USED_IN_ANALYSIS')
+
+# Connect from Result node to Project node
+def db_connect_result_to_project(result_node_name, project_node_name):
+    return db_connect_with_relationship('Result', result_node_name, 'Project', project_node_name, 'BELONGS_TO')
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -484,6 +484,10 @@ class database:
         """Set Result property. Creates/overwrites current data.""" 
         return self.__set_node_property(self.result_type, self.result_id, id_value, property_name, new_data)
     
+    def lookup_result_property(self, id_value, property_name):
+        """Return data of specific property from Result""" 
+        return self.__lookup_node_property(self.result_type, self.result_id, id_value, property_name)
+    
     def delete_result(self, id_value):
         """Delete Result node""" 
         return self.__delete_node_with_connections(self.result_type, self.result_id, id_value)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -255,8 +255,6 @@ class database:
             database_= self.__name,
         )
 
-        print(records)
-
         if not records:
             return False
         else:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -11,7 +11,7 @@ class NodeProperties:
         # Settings
         # example <FOO> = "foo"
         TEST_PASS = "test_pass"
-        TEST_FAILED = "test_failed"
+        TEST_FAIL = "test_fail"
 
 
     class UserSettings(Enum):
@@ -20,7 +20,7 @@ class NodeProperties:
         NAME = "name"
 
         TEST_PASS = "test_pass"
-        TEST_FAILED = "test_failed"
+        TEST_FAIL = "test_fail"
 
     # has only one property, enforced by function call
     #class Dataset(Enum):
@@ -36,7 +36,7 @@ class NodeProperties:
         RELATIONSHIP_TYPES = "relationship_types"
 
         TEST_PASS = "test_pass"
-        TEST_FAILED = "test_failed"
+        TEST_FAIL = "test_fail"
 
     
     class AnalyzeModel(Enum):
@@ -46,7 +46,7 @@ class NodeProperties:
         KEYWORDS = "keywords"
 
         TEST_PASS = "test_pass"
-        TEST_FAILED = "test_failed"
+        TEST_FAIL = "test_fail"
 
     class Project(Enum):
         # Project
@@ -54,13 +54,13 @@ class NodeProperties:
         NAME = "name"
         
         TEST_PASS = "test_pass"
-        TEST_FAILED = "test_failed"
+        TEST_FAIL = "test_fail"
 
     class Result(Enum):
         # Result
         # example <FOO> = "foo"
         TEST_PASS = "test_pass"
-        TEST_FAILED = "test_failed"
+        TEST_FAIL = "test_fail"
 
 
 class Database:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -159,7 +159,7 @@ class database:
             "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) "
             "RETURN n." + property_name + " AS " + property_name
         )
-        
+
         records, summary, keys = self.__driver.execute_query(
             query_string,
             database_= self.__name,
@@ -321,7 +321,31 @@ class database:
         except:
             return None
     
-    def __does_node_property_exist(self, type, id_type, id_value):
+    def __does_property_exist(self, type, id_type, id_value, property_name):
+        """return true/false
+        Check if node exists with specific node type and property value
+        """
+        id_value = str(id_value)
+        query_string = (
+            "MATCH (a:" + type + " {" + id_type + ": '" + id_value + "'}) "
+            "WHERE a." + property_name + " IS NOT NULL "
+            "RETURN a"
+        )
+
+        try:
+            records, summary, keys = self.__driver.execute_query(
+                query_string,
+                database_= self.__name,
+            )
+        
+            if not records:
+                return False
+            else:
+                return True
+        except:
+            return False
+        
+    def __does_node_exist(self, type, id_type, id_value):
         """return true/false
         Check if node exists with specific node type and property value
         """
@@ -399,7 +423,7 @@ class database:
     
     ### Global settings
     def add_global_settings_node(self):
-        """Create global settings node"""        
+        """Create global settings node"""
         return self.__add_node(self.__global_settings_type, self.__global_settings_id, self.__global_settings_id_value)
 
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -141,6 +141,16 @@ def db_delete_property(node_type, node_name, property_name):
     )
     return "Deleted: " + node_type + "(" + node_name + ")." + property_name
 
+def db_connect_with_relationship(node_type_a, node_name_a, node_type_b, node_name_b, relationship_type):
+    # define query string within python, because driver doesn't allow property types being a variable
+    query_string = "MATCH (n:" + node_type_a + " {name: '" + node_name_a + "'}) MATCH (m:" + node_type_b + " {name: '" + node_name_b + "'}) MERGE (n)-[:" + relationship_type + "]->(m)"
+
+    driver.execute_query(
+        query_string,
+        database_= database_name,
+    )
+    return "Connected: " + node_type_a + "(" + node_name_a + ")->" + node_type_b + "(" + node_name_b + ")"
+
 
 """
 Global settings functions
@@ -253,3 +263,15 @@ def db_lookup_dataset_data(node_id):
 # Deletes specific Dataset with all it's related content.
 def db_delete_dataset(node_id):
     return db_delete_node('Dataset', node_id)
+
+"""
+Connection functions
+"""
+# Connect from dataset node to subject area node
+def db_connect_dataset_to_subject_area(dataset_node_id, subject_area_node_name):
+    return db_connect_with_relationship('Dataset', dataset_node_id, 'SubjectArea', subject_area_node_name, 'DATA_ANALYSATION')
+
+# Connect from dataset node to model node
+def db_connect_dataset_to_model(dataset_node_id, model_node_name):
+    return db_connect_with_relationship('Dataset', dataset_node_id, 'Model', model_node_name, 'MODEL_CREATION')
+

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -33,11 +33,28 @@ class database:
         self.result_type = 'Result'
         self.result_id = 'id'
         
-        self.used_analyze_model_type = 'UsedAlayzeModel'
-        self.used_analyze_model_id = 'id'
-        
         self.used_dataset_type = 'UsedDataSet'
         self.used_dataset_id = 'id'
+
+        self.used_data_model_type = 'UsedDataModel'
+        self.used_data_model_id = 'id'
+
+        self.used_analyze_model_type = 'UsedAnalyzeModel'
+        self.used_analyze_model_id = 'id'
+        
+
+        self.connect_dataset_data_model = 'USED_FOR_TRAINING'
+        self.connect_dataset_analyze_model = 'USED_FOR_TRAINING'
+                
+        self.connect_dataset_project = 'ANALYZED_IN'
+        self.connect_result_project = 'BELONGS_TO'
+        self.connect_data_model_project = 'ACTIVE_IN'
+
+        self.connect_used_analyze_model_result = 'USED_IN_ANALYSIS'
+        self.connect_used_data_model_result = 'USED_IN_ANALYSIS'
+        self.connect_used_dataset_result = 'USED_IN_ANALYSIS'
+        self.connect_used_dataset_used_data_model = 'USED_FOR_TRAINING'
+        self.connect_used_dataset_used_analyze_model = 'USED_FOR_TRAINING'
 
 
     def debug_clear_all(self):
@@ -139,7 +156,6 @@ class database:
         id_value = str(id_value)
         if exclude_relationships == None:
             query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) <- [*0..] - (d) DETACH DELETE n WITH DISTINCT d DETACH DELETE d"
-        # todo: make this work with list of exclusions
         elif isinstance(exclude_relationships,list):
             exclude_relationships = "','".join(exclude_relationships)
             query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) <- [r*0..] - (d) WHERE NONE ( rel IN r WHERE type(rel) IN ['"+ exclude_relationships + "']) DETACH DELETE n WITH DISTINCT d DETACH DELETE d"
@@ -209,6 +225,57 @@ class database:
             database_= self.name,
         )
         return "Copied " + type + "(" + id_value + ") to " + node_type_new + "(" + id_value_new + ")"
+    
+    ### Connections
+    def connect_dataset_to_data_model(self, dataset_id_value, data_model_id_value):
+        """Connect Dataset to DataModel"""
+        return self.__connect_with_relationship(self.dataset_type, dataset_id_value, self.data_model_type, data_model_id_value, self.connect_dataset_data_model)
+    
+
+    def connect_dataset_to_analyze_model(self, dataset_id_value, analyze_model_id_value):
+        """Connect Dataset to AnalyzeModel"""
+        return self.__connect_with_relationship(self.dataset_type, dataset_id_value, self.analyze_model_type, analyze_model_id_value, self.connect_dataset_analyze_model)
+    
+
+    def connect_data_model_to_project(self, data_model_id_value, project_id_value):
+        """Connect DataModel to Project"""
+        return self.__connect_with_relationship(self.data_model_type, data_model_id_value, self.project_type, project_id_value, self.connect_data_model_project)
+
+
+    def connect_dataset_to_project(self, dataset_id_value, project_id_value):
+        """Connect Dataset to Project"""
+        return self.__connect_with_relationship(self.dataset_type, dataset_id_value, self.project_type, project_id_value, self.connect_dataset_project)
+
+
+    def __connect_result_to_project(self, result_id_value, project_id_value):
+        """Connect Result to Project"""
+        return self.__connect_with_relationship(self.result_type, result_id_value, self.project_type, project_id_value, self.connect_result_project)
+    
+
+    def __connect_used_dataset_to_result(self, used_dataset_id_value, result_id_value):
+        """Connect UsedDataset to Result"""
+        return self.__connect_with_relationship(self.used_dataset_type, used_dataset_id_value, self.result_type, result_id_value, self.connect_used_dataset_result)
+
+
+    def __connect_used_analyze_model_to_result(self, used_analyze_model_id_value, result_id_value):
+        """Connect UsedAnalyzeModel to Result"""
+        return self.__connect_with_relationship(self.used_analyze_model_type, used_analyze_model_id_value, self.result_type, result_id_value, self.connect_used_analyze_model_result)
+    
+
+    def __connect_used_data_model_to_result(self, used_data_model_id_value, result_id_value):
+        """Connect UsedDataModel to Result"""
+        return self.__connect_with_relationship(self.used_data_model_type, used_data_model_id_value, self.result_type, result_id_value, self.connect_used_data_model_result)
+    
+
+    def __connect_used_dataset_to_used_data_model(self, used_dataset_id_value, used_data_model_id_value):
+        """Connect UsedDataset to UsedDataModel"""
+        return self.__connect_with_relationship(self.used_dataset_type, used_dataset_id_value, self.used_data_model_type, used_data_model_id_value, self.connect_used_dataset_used_data_model)
+    
+
+    def __connect_used_dataset_to_used_analyze_model(self, used_dataset_id_value, used_analyze_model_id_value):
+        """Connect UsedDataset to UsedAnalyzeModel"""
+        return self.__connect_with_relationship(self.used_dataset_type, used_dataset_id_value, self.used_analyze_model_type, used_analyze_model_id_value, self.connect_used_dataset_used_analyze_model)
+
     
     ### Global settings
     def add_global_settings_node(self):
@@ -286,4 +353,7 @@ class database:
     def delete_project(self, id_value):
         """Delete project node""" 
         return self.__delete_node_with_connections(self.project_type, self.project_id, id_value, self.project_exclusion)
+    
+
+
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -182,6 +182,17 @@ def db_connect_with_relationship(node_type_a, node_name_a, node_type_b, node_nam
     return "Connected: " + node_type_a + "(" + node_name_a + ")->" + node_type_b + "(" + node_name_b + ")"
 
 
+def db_copy_node(node_type, new_node_type, id_type, id_value):
+    # define query string within python, because driver doesn't allow property types being a variable
+    query_string = "MATCH (n:" + node_type + " {" + id_type + ":" + id_value + "}) SET n:" + new_node_type
+
+    driver.execute_query(
+        query_string,
+        database_= database_name,
+    )
+    return "Copied " + node_type + "(" + id_value + ") to " + new_node_type + "(" + id_value + ")"
+
+
 """
 Global settings functions
 """
@@ -320,7 +331,18 @@ def db_lookup_analyze_model_data(node_name, property_name):
 def db_delete_analyze_model(node_name):
     return db_delete_node_with_connections('AnalyzeModel', node_name)
 
+"""
+UsedAnalyzeModel functions
+"""
+# Create new UsedAnalyzeModel from a copy of AnalyzeModel
+# Connect it with Result
+def db_add_used_analyze_model_node(model_node_name, result_node_name):
+    return_a = db_copy_node('AnalyzeModel','UsedAnalyzeModel', 'name', model_node_name)
+    return_b = db_connect_dataset_to_analyze_model(model_node_name, result_node_name)
+    return return_a + "and" + return_b
 
+
+db_copy_node
 """
 Dataset functions
 """
@@ -354,4 +376,8 @@ def db_connect_dataset_to_data_model(dataset_node_id, model_node_name):
 # Connect from Dataset node to AnalyzeModel node
 def db_connect_dataset_to_analyze_model(dataset_node_id, model_node_name):
     return db_connect_with_relationship('Dataset', dataset_node_id, 'AnalyzeModel', model_node_name, 'USED_FOR_TRAINING')
+
+# Connect from UsedAnalyzeModel node to Result node
+def db_connect_used_analyze_model_to_result(model_node_name, result_node_name):
+    return db_connect_with_relationship('UsedAnalyzeModel', model_node_name, 'Result', result_node_name, 'USED_IN_ANALYSIS')
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -77,7 +77,7 @@ class NodeProperties:
 class Database:
     def __init__(self) -> None:
         """Start up database connection.
-        Setup types and identifier names according to database design v3.
+        Setup types and identifier names according to database design v4.
         """
         #self.__enum_properties = NodeProperties()
 
@@ -523,7 +523,7 @@ class Database:
     def __connect_used_data_model_to_result(self, used_data_model_id_value, result_id_value):
         """Connect UsedDataModel to Result"""
         return self.__connect_with_relationship(self.__used_data_model_type, self.__used_data_model_id, used_data_model_id_value, self.__result_type, self.__result_id, result_id_value, self.__connect_used_data_model_result)
-    
+
 
     def __connect_used_dataset_to_used_data_model(self, used_dataset_id_value, used_data_model_id_value):
         """Connect UsedDataset to UsedDataModel"""

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -184,7 +184,7 @@ def db_connect_with_relationship(node_type_a, node_name_a, node_type_b, node_nam
 
 def db_copy_node(node_type, new_node_type, id_type, id_value):
     # define query string within python, because driver doesn't allow property types being a variable
-    query_string = "MATCH (n:" + node_type + " {" + id_type + ":" + id_value + "}) SET n:" + new_node_type
+    query_string = "MATCH (n:" + node_type + " {" + id_type + ": '" + id_value + "'}) SET n:" + new_node_type
 
     driver.execute_query(
         query_string,

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -184,7 +184,7 @@ def db_connect_with_relationship(node_type_a, node_name_a, node_type_b, node_nam
 
 def db_copy_node(node_type, new_node_type, id_type, id_value):
     # define query string within python, because driver doesn't allow property types being a variable
-    query_string = "MATCH (n:" + node_type + " {" + id_type + ": '" + id_value + "'}) CREATE (m:" + new_node_type + ") SET m = properties(n)"
+    query_string = "MATCH (n:" + node_type + " {" + id_type + ": '" + id_value + "'}) MERGE (m:" + new_node_type + " {" + id_type + ": '" + id_value + "'}) SET m = properties(n)"
 
     driver.execute_query(
         query_string,
@@ -212,7 +212,7 @@ def db_delete_settings_data(property_name):
 def db_lookup_settings_data(property_name):
     return db_lookup_node_property('Settings', settings_node_name, property_name)
 
-# Deletes global settings with all it's related content.
+# Deletes settings with all it's related content.
 def db_delete_settings():
     return db_delete_node('Settings', settings_node_name)
 
@@ -235,7 +235,7 @@ def db_delete_user_settings_data(user_name, property_name):
 def db_lookup_user_settings_data(user_name, property_name):
     return db_lookup_node_property('UserSettings', user_name, property_name)
 
-# Deletes global UserSettings with all it's related content.
+# Deletes UserSettings with all it's related content.
 def db_delete_user_settings(user_name):
     return db_delete_node('UserSettings', user_name)
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -243,7 +243,7 @@ class database:
         except:
             return "ERROR: Property not found"
     
-    def __does_node_exist(self, type, id_type, id_value):
+    def __does_node_property_exist(self, type, id_type, id_value):
         """return true/false
         Check if node exists with specific node type and property value
         """

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -4,9 +4,39 @@ import os
 
 class database:
     def __init__(self) -> None:
+        """Start up database connection.
+        Setup types and identifier names according to database design.
+        """
         self.driver = GraphDatabase.driver(os.getenv('NEO4J_URL'), auth=(os.getenv('NEO4J_USER'), os.getenv('NEO4J_PASSWORD')))
         self.name = 'neo4j'     # database name
-        self.global_settings_name = 'Global'
+
+        self.global_settings_type = 'Settings'
+        self.global_settings_id = 'name'
+        self.global_settings_id_value = 'Global'
+
+        self.user_settings_type = 'UserSettings'
+        self.user_settings_id = 'user_name'
+        
+        self.dataset_type = 'Dataset'
+        self.dataset_id = 'id'
+        
+        self.data_model_type = 'DataModel'
+        self.data_model_id = 'id'
+        
+        self.analyze_model_type = 'AnalyzeModel'
+        self.analyze_model_id = 'id'
+        
+        self.project_type = 'Project'
+        self.project_id = 'id'
+        
+        self.result_type = 'Result'
+        self.result_id = 'id'
+        
+        self.used_analyze_model_type = 'UsedAlayzeModel'
+        self.used_analyze_model_id = 'id'
+        
+        self.used_dataset_type = 'UsedDataSet'
+        self.used_dataset_id = 'id'
 
 
     def debug_clear_all(self):
@@ -163,3 +193,5 @@ class database:
             database_= self.name,
         )
         return "Copied " + type + "(" + id_value + ") to " + node_type_new + "(" + id_value_new + ")"
+
+

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -328,12 +328,12 @@ def db_add_dataset_node(node_id):
     return db_add_node('Dataset', node_id)
 
 # Modify Dataset-node's properties. Replaces data with new data.
-def db_modify_dataset_data(node_id, new_data):
-    return db_modify_node_data('Dataset', node_id, 'data', new_data)
+def db_modify_dataset_data(node_id, file_name):
+    return db_modify_node_data('Dataset', node_id, 'Filename', file_name)
 
 # Return data of specific property from Dataset-node
 def db_lookup_dataset_data(node_id):
-    return db_lookup_node_property('Dataset', node_id, 'data')
+    return db_lookup_node_property('Dataset', node_id, 'Filename')
 
 # Deletes specific Dataset with all it's related content.
 def db_delete_dataset(node_id):

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -300,25 +300,26 @@ def db_delete_data_model(node_name):
 """
 AnalyzeModel functions
 """
-# Create new Model-node with specific name. Avoids duplicates.
+# Create new AnalyzeModel-node with specific name. Avoids duplicates.
 def db_add_analyze_model_node(node_name):
     return db_add_node('AnalyzeModel', node_name)
 
-# Modify Model-node's properties. Replaces specific property with new data.
+# Modify AnalyzeModel-node's properties. Replaces specific property with new data.
 def db_modify_analyze_model_data(node_name, property_name, new_data):
     return db_modify_node_data('AnalyzeModel', node_name, property_name, new_data)
 
-# Removes specific Model property data (and property).
+# Removes specific AnalyzeModel property data (and property).
 def db_delete_analyze_model_data(node_name, property_name):
     return db_delete_property('AnalyzeModel', node_name, property_name)
 
-# Return data of specific property from Model-node
+# Return data of specific property from AnalyzeModel-node
 def db_lookup_analyze_model_data(node_name, property_name):
     return db_lookup_node_property('AnalyzeModel', node_name, property_name)
 
-# Deletes specific Model with all it's related content.
+# Deletes specific AnalyzeModel with all it's related content.
 def db_delete_analyze_model(node_name):
     return db_delete_node_with_connections('AnalyzeModel', node_name)
+
 
 """
 Dataset functions

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -184,7 +184,7 @@ def db_connect_with_relationship(node_type_a, node_name_a, node_type_b, node_nam
 
 def db_copy_node(node_type, new_node_type, id_type, id_value):
     # define query string within python, because driver doesn't allow property types being a variable
-    query_string = "MATCH (n:" + node_type + " {" + id_type + ": '" + id_value + "'}) SET n:" + new_node_type
+    query_string = "MATCH (n:" + node_type + " {" + id_type + ": '" + id_value + "'}) CREATE (m:" + new_node_type + ") SET m = properties(n)"
 
     driver.execute_query(
         query_string,
@@ -344,7 +344,7 @@ UsedAnalyzeModel functions
 # Connect it with Result
 def db_add_used_analyze_model_node(model_node_name, result_node_name):
     return_a = db_copy_node('AnalyzeModel','UsedAnalyzeModel', 'name', model_node_name)
-    return_b = db_connect_dataset_to_analyze_model(model_node_name, result_node_name)
+    return_b = db_connect_used_analyze_model_to_result(model_node_name, result_node_name)
     return return_a + " and " + return_b
 
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,6 +1,7 @@
 from neo4j import GraphDatabase
 from dotenv import load_dotenv
 from enum import Enum
+from datetime import datetime
 import os
 
 class NodeProperties:
@@ -73,6 +74,7 @@ class NodeProperties:
         # Result
         # example <FOO> = "foo"
         RESULT = "result"
+        DATETIME = "datetime"
 
         TEST_PASS = "test_pass"
         TEST_FAIL = "test_fail"
@@ -211,7 +213,13 @@ class Database:
         # check if node exists
         if not self.__does_node_exist(type, id_type, id_value):
             return False
-        id_value = str(id_value)
+        
+        # is new data datetime
+        try:
+            datetime.strptime(new_data, "%Y-%m-%dT%H:%M:%S")
+        except:
+            id_value = str(id_value)
+
         query_string = (
             "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) "
             "SET n." + property_name + " = $old_data" 
@@ -269,6 +277,9 @@ class Database:
             return next(iter(records)).data()[property_name]
         except:
             return None
+
+
+
         
         
     def __delete_node_with_connections(self, type, id_type, id_value, exclude_relationships = None):
@@ -812,6 +823,7 @@ class Database:
         try:
             
             result_blueprint_id = self.__add_node(self.__result_blueprint_type, self.__result_blueprint_id)
+            self.set_result_blueprint_property(result_blueprint_id, NodeProperties.ResultBlueprint.DATETIME, datetime.now().isoformat())
             
             # copy nodes into used node versions and connect them to result
             for file_name in dataset_list:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -236,12 +236,12 @@ class database:
         return self.__remove_property(self.user_settings_type, self.user_settings_id, id_value, property_name)
 
 
-    def lookup_global_settings_property(self, id_value, property_name):
+    def lookup_user_settings_property(self, id_value, property_name):
         """Return data of specific property from settings""" 
         return self.__lookup_node_property(self.user_settings_type, self.user_settings_id, id_value, property_name)
     
 
-    def delete_global_settings(self, id_value):
+    def delete_user_settings(self, id_value):
         """Delete global settings node""" 
         return self.__delete_node(self.user_settings_type, self.user_settings_id, id_value)
     

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -20,7 +20,7 @@ db_add_settings_node() , creates settings node
 db_modify_settings_data(property_name, data) , modifies specific property with specific data
 db_lookup_settings_data(property_name) , lookup specific property data
 db_delete_settings_data(property_name) , delete specific property data (also delete property)
-db_delete_settings() , deletes settings with all it's related content.
+db_delete_settings() , deletes settings node.
 
 Subject area:
 db_add_subject_area_node(node_name) , creates subject area node of specific name

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -3,23 +3,29 @@ from dotenv import load_dotenv
 from enum import Enum
 import os
 
-class NodeProperties():
+class NodeProperties:
     """All allowed property names for each node type.
     """
-    class Settings(Enum):
+    class GlobalSettings(Enum):
         # Settings
         # example <FOO> = "foo"
-        pass
+        TEST_PASS = "test_pass"
+        TEST_FAILED = "test_failed"
+
 
     class UserSettings(Enum):
         # User settings
         # example <FOO> = "foo"
         NAME = "name"
 
-    class Dataset(Enum):
+        TEST_PASS = "test_pass"
+        TEST_FAILED = "test_failed"
+
+    # has only one property, enforced by function call
+    #class Dataset(Enum):
         # Dataset
         # example <FOO> = "foo"
-        FILE_NAME = "file_name"
+    #    FILE_NAME = "file_name"
 
     class DataModel(Enum):
         # Data model
@@ -27,6 +33,10 @@ class NodeProperties():
         NAME = "name"
         NODE_TYPES = "node_types"
         RELATIONSHIP_TYPES = "relationship_types"
+
+        TEST_PASS = "test_pass"
+        TEST_FAILED = "test_failed"
+
     
     class AnalyzeModel(Enum):
         # Analyze model
@@ -34,15 +44,22 @@ class NodeProperties():
         NAME = "name"
         KEYWORDS = "keywords"
 
+        TEST_PASS = "test_pass"
+        TEST_FAILED = "test_failed"
+
     class Project(Enum):
         # Project
         # example <FOO> = "foo"
         NAME = "name"
+        
+        TEST_PASS = "test_pass"
+        TEST_FAILED = "test_failed"
 
     class Result(Enum):
         # Result
         # example <FOO> = "foo"
-        pass
+        TEST_PASS = "test_pass"
+        TEST_FAILED = "test_failed"
 
 
 class Database:
@@ -50,6 +67,8 @@ class Database:
         """Start up database connection.
         Setup types and identifier names according to database design v3.
         """
+        #self.__enum_properties = NodeProperties()
+
         self.__driver = GraphDatabase.driver(os.getenv('NEO4J_URL'), auth=(os.getenv('NEO4J_USER'), os.getenv('NEO4J_PASSWORD')))
         self.__name = os.getenv('NEO4J_DB_NAME')
 
@@ -507,19 +526,19 @@ class Database:
         return self.__add_node(self.__global_settings_type, self.__global_settings_id, self.__global_settings_id_value)
 
 
-    def set_global_settings_property(self, property_name, new_data):
+    def set_global_settings_property(self, property_name: NodeProperties.GlobalSettings, new_data):
         """Set global settings property data.""" 
-        return self.__set_node_property(self.__global_settings_type, self.__global_settings_id, self.__global_settings_id_value, property_name, new_data)
+        return self.__set_node_property(self.__global_settings_type, self.__global_settings_id, self.__global_settings_id_value, property_name.value, new_data)
     
         
-    def remove_global_settings_property(self, property_name):
+    def remove_global_settings_property(self, property_name: NodeProperties.GlobalSettings):
         """Removes specific Settings property data (and property)""" 
-        return self.__remove_property(self.__global_settings_type, self.__global_settings_id, self.__global_settings_id_value, property_name)
+        return self.__remove_property(self.__global_settings_type, self.__global_settings_id, self.__global_settings_id_value, property_name.value)
 
 
-    def lookup_global_settings_property(self, property_name):
+    def lookup_global_settings_property(self, property_name: NodeProperties.GlobalSettings):
         """Return data of specific property from settings""" 
-        return self.__lookup_node_property(self.__global_settings_type, self.__global_settings_id, self.__global_settings_id_value, property_name)
+        return self.__lookup_node_property(self.__global_settings_type, self.__global_settings_id, self.__global_settings_id_value, property_name.value)
     
 
     def delete_global_settings(self):
@@ -538,19 +557,19 @@ class Database:
         return self.__add_node(self.__user_settings_type, self.__user_settings_id, id_value)
 
 
-    def set_user_settings_property(self, id_value, property_name, new_data):
+    def set_user_settings_property(self, id_value, property_name: NodeProperties.UserSettings, new_data):
         """Set user settings property. Creates/overwrites current data.""" 
-        return self.__set_node_property(self.__user_settings_type, self.__user_settings_id, id_value, property_name, new_data)
+        return self.__set_node_property(self.__user_settings_type, self.__user_settings_id, id_value, property_name.value, new_data)
     
         
-    def remove_user_settings_property(self, id_value, property_name):
+    def remove_user_settings_property(self, id_value, property_name: NodeProperties.UserSettings):
         """Removes specific Settings property data (and property)""" 
-        return self.__remove_property(self.__user_settings_type, self.__user_settings_id, id_value, property_name)
+        return self.__remove_property(self.__user_settings_type, self.__user_settings_id, id_value, property_name.value)
 
 
-    def lookup_user_settings_property(self, id_value, property_name):
+    def lookup_user_settings_property(self, id_value, property_name: NodeProperties.UserSettings):
         """Return data of specific property from settings""" 
-        return self.__lookup_node_property(self.__user_settings_type, self.__user_settings_id, id_value, property_name)
+        return self.__lookup_node_property(self.__user_settings_type, self.__user_settings_id, id_value, property_name.value)
     
 
     def delete_user_settings(self, id_value):
@@ -569,19 +588,19 @@ class Database:
         return self.__add_node(self.__project_type, self.__project_id)
 
 
-    def set_project_property(self, id_value, property_name, new_data):
+    def set_project_property(self, id_value, property_name: NodeProperties.Project, new_data):
         """Set Project property. Creates/overwrites current data.""" 
-        return self.__set_node_property(self.__project_type, self.__project_id, id_value, property_name, new_data)
+        return self.__set_node_property(self.__project_type, self.__project_id, id_value, property_name.value, new_data)
     
         
-    def remove_project_property(self, id_value, property_name):
+    def remove_project_property(self, id_value, property_name: NodeProperties.Project):
         """Removes specific Project property data (and property)""" 
-        return self.__remove_property(self.__project_type, self.__project_id, id_value, property_name)
+        return self.__remove_property(self.__project_type, self.__project_id, id_value, property_name.value)
 
 
-    def lookup_project_property(self, id_value, property_name):
+    def lookup_project_property(self, id_value, property_name: NodeProperties.Project):
         """Return data of specific property from Project""" 
-        return self.__lookup_node_property(self.__project_type, self.__project_id, id_value, property_name)
+        return self.__lookup_node_property(self.__project_type, self.__project_id, id_value, property_name.value)
     
 
     def delete_project(self, id_value):
@@ -632,19 +651,19 @@ class Database:
         return self.__add_node(self.__data_model_type, self.__data_model_id)
 
 
-    def set_data_model_property(self, id_value, property_name, new_data):
+    def set_data_model_property(self, id_value, property_name: NodeProperties.DataModel, new_data):
         """Set DataModel property. Creates/overwrites current data.""" 
-        return self.__set_node_property(self.__data_model_type, self.__data_model_id, id_value, property_name, new_data)
+        return self.__set_node_property(self.__data_model_type, self.__data_model_id, id_value, property_name.value, new_data)
     
         
-    def remove_data_model_property(self, id_value, property_name):
+    def remove_data_model_property(self, id_value, property_name: NodeProperties.DataModel):
         """Removes specific DataModel property data (and property)""" 
-        return self.__remove_property(self.__data_model_type, self.__data_model_id, id_value, property_name)
+        return self.__remove_property(self.__data_model_type, self.__data_model_id, id_value, property_name.value)
 
 
-    def lookup_data_model_property(self, id_value, property_name):
+    def lookup_data_model_property(self, id_value, property_name: NodeProperties.DataModel):
         """Return data of specific property from DataModel""" 
-        return self.__lookup_node_property(self.__data_model_type, self.__data_model_id, id_value, property_name)
+        return self.__lookup_node_property(self.__data_model_type, self.__data_model_id, id_value, property_name.value)
     
 
     def delete_data_model(self, id_value):
@@ -663,19 +682,19 @@ class Database:
         return self.__add_node(self.__analyze_model_type, self.__analyze_model_id)
 
 
-    def set_analyze_model_property(self, id_value, property_name, new_data):
+    def set_analyze_model_property(self, id_value, property_name: NodeProperties.AnalyzeModel, new_data):
         """Set AnalyzeModel property. Creates/overwrites current data.""" 
-        return self.__set_node_property(self.__analyze_model_type, self.__analyze_model_id, id_value, property_name, new_data)
+        return self.__set_node_property(self.__analyze_model_type, self.__analyze_model_id, id_value, property_name.value, new_data)
     
         
-    def remove_analyze_model_property(self, id_value, property_name):
+    def remove_analyze_model_property(self, id_value, property_name: NodeProperties.AnalyzeModel):
         """Removes specific AnalyzeModel property data (and property)""" 
-        return self.__remove_property(self.__analyze_model_type, self.__analyze_model_id, id_value, property_name)
+        return self.__remove_property(self.__analyze_model_type, self.__analyze_model_id, id_value, property_name.value)
 
 
-    def lookup_analyze_model_property(self, id_value, property_name):
+    def lookup_analyze_model_property(self, id_value, property_name: NodeProperties.AnalyzeModel):
         """Return data of specific property from AnalyzeModel""" 
-        return self.__lookup_node_property(self.__analyze_model_type, self.__analyze_model_id, id_value, property_name)
+        return self.__lookup_node_property(self.__analyze_model_type, self.__analyze_model_id, id_value, property_name.value)
     
 
     def delete_analyze_model(self, id_value):

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -22,11 +22,13 @@ class NodeProperties:
         TEST_PASS = "test_pass"
         TEST_FAIL = "test_fail"
 
+
     # has only one property, enforced by function call
     #class Dataset(Enum):
         # Dataset
         # example <FOO> = "foo"
     #    FILE_NAME = "file_name"
+
 
     class DataModel(Enum):
         # Data model
@@ -38,7 +40,14 @@ class NodeProperties:
         TEST_PASS = "test_pass"
         TEST_FAIL = "test_fail"
 
+
+    class Blueprint(Enum):
+        # Blueprint
+        # example <FOO> = "foo"
+        TEST_PASS = "test_pass"
+        TEST_FAIL = "test_fail"
     
+
     class AnalyzeModel(Enum):
         # Analyze model
         # example <FOO> = "foo"
@@ -48,6 +57,7 @@ class NodeProperties:
         TEST_PASS = "test_pass"
         TEST_FAIL = "test_fail"
 
+
     class Project(Enum):
         # Project
         # example <FOO> = "foo"
@@ -55,6 +65,7 @@ class NodeProperties:
         
         TEST_PASS = "test_pass"
         TEST_FAIL = "test_fail"
+
 
     class Result(Enum):
         # Result
@@ -89,6 +100,9 @@ class Database:
         
         self.__analyze_model_type = 'AnalyzeModel'
         self.__analyze_model_id = 'id'
+
+        self.__blueprint_type = 'Blueprint'
+        self.__blueprint_id = 'id'
         
         self.__project_type = 'Project'
         self.__project_id = 'id'
@@ -673,9 +687,40 @@ class Database:
     
 
     def get_data_model_id_type(self):
-        """Get data model id type""" 
+        """Get DataModel id type""" 
         return self.__data_model_id
     
+
+    ### Blueprint
+    def add_blueprint_node(self):
+        """Create Blueprint node. Avoids duplicates."""
+        return self.__add_node(self.__blueprint_type, self.__blueprint_id)
+
+
+    def set_blueprint_property(self, id_value, property_name: NodeProperties.DataModel, new_data):
+        """Set Blueprint property. Creates/overwrites current data.""" 
+        return self.__set_node_property(self.__blueprint_type, self.__blueprint_id, id_value, property_name.value, new_data)
+    
+        
+    def remove_blueprint_property(self, id_value, property_name: NodeProperties.DataModel):
+        """Removes specific Blueprint property data (and property)""" 
+        return self.__remove_property(self.__blueprint_type, self.__data_model_id, id_value, property_name.value)
+
+
+    def lookup_blueprint_property(self, id_value, property_name: NodeProperties.DataModel):
+        """Return data of specific property from Blueprint""" 
+        return self.__lookup_node_property(self.__blueprint_type, self.__data_model_id, id_value, property_name.value)
+    
+
+    def delete_blueprint(self, id_value):
+        """Delete Blueprint node""" 
+        return self.__delete_node_with_connections(self.__blueprint_type, self.__data_model_id, id_value)
+    
+
+    def get_blueprint_id_type(self):
+        """Get Blueprint id type""" 
+        return self.__data_model_id
+
 
         ### AnalyzeModel
     def add_analyze_model_node(self):
@@ -704,7 +749,7 @@ class Database:
     
 
     def get_analyze_model_id_type(self):
-        """Get analyze model id type""" 
+        """Get AnalyzeModel id type""" 
         return self.__analyze_model_id
 
    

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -239,21 +239,17 @@ def db_delete_model(node_name):
 Dataset functions
 """
 # Create new Dataset-node with specific name. Avoids duplicates.
-def db_add_dataset_node(node_name):
-    return db_add_node('Dataset', node_name)
+def db_add_dataset_node(node_id):
+    return db_add_node('Dataset', node_id)
 
-# Modify Dataset-node's properties. Replaces specific property with new data.
-def db_modify_dataset_data(node_name, property_name, new_data):
-    return db_modify_node_data('Dataset', node_name, property_name, new_data)
-
-# Removes specific Dataset property data (and property).
-def db_delete_dataset_data(node_name, property_name):
-    return db_delete_property('Dataset', node_name, property_name)
+# Modify Dataset-node's properties. Replaces data with new data.
+def db_modify_dataset_data(node_id, new_data):
+    return db_modify_node_data('Dataset', node_id, 'data', new_data)
 
 # Return data of specific property from Dataset-node
-def db_lookup_dataset_data(node_name, property_name):
-    return db_lookup_node_property('Dataset', node_name, property_name)
+def db_lookup_dataset_data(node_id):
+    return db_lookup_node_property('Dataset', node_id, 'data')
 
 # Deletes specific Dataset with all it's related content.
-def db_delete_dataset(node_name):
-    return db_delete_node('Dataset', node_name)
+def db_delete_dataset(node_id):
+    return db_delete_node('Dataset', node_id)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -248,52 +248,52 @@ class database:
     ### Connections
     def connect_dataset_to_data_model(self, dataset_id_value, data_model_id_value):
         """Connect Dataset to DataModel"""
-        return self.__connect_with_relationship(self.dataset_type, dataset_id_value, self.data_model_type, data_model_id_value, self.connect_dataset_data_model)
+        return self.__connect_with_relationship(self.dataset_type, self.dataset_id, dataset_id_value, self.data_model_type, self.data_model_id, data_model_id_value, self.connect_dataset_data_model)
     
 
     def connect_dataset_to_analyze_model(self, dataset_id_value, analyze_model_id_value):
         """Connect Dataset to AnalyzeModel"""
-        return self.__connect_with_relationship(self.dataset_type, dataset_id_value, self.analyze_model_type, analyze_model_id_value, self.connect_dataset_analyze_model)
+        return self.__connect_with_relationship(self.dataset_type, self.dataset_id, dataset_id_value, self.analyze_model_type, self.analyze_model_id, analyze_model_id_value, self.connect_dataset_analyze_model)
     
 
     def connect_data_model_to_project(self, data_model_id_value, project_id_value):
         """Connect DataModel to Project"""
-        return self.__connect_with_relationship(self.data_model_type, data_model_id_value, self.project_type, project_id_value, self.connect_data_model_project)
+        return self.__connect_with_relationship(self.data_model_type, self.data_model_id, data_model_id_value, self.project_type, self.project_id, project_id_value, self.connect_data_model_project)
 
 
     def connect_dataset_to_project(self, dataset_id_value, project_id_value):
         """Connect Dataset to Project"""
-        return self.__connect_with_relationship(self.dataset_type, dataset_id_value, self.project_type, project_id_value, self.connect_dataset_project)
+        return self.__connect_with_relationship(self.dataset_type, self.dataset_id, dataset_id_value, self.project_type, self.project_id, project_id_value, self.connect_dataset_project)
 
 
     def __connect_result_to_project(self, result_id_value, project_id_value):
         """Connect Result to Project"""
-        return self.__connect_with_relationship(self.result_type, result_id_value, self.project_type, project_id_value, self.connect_result_project)
+        return self.__connect_with_relationship(self.result_type, self.result_id, result_id_value, self.project_type, self.project_id, project_id_value, self.connect_result_project)
     
 
     def __connect_used_dataset_to_result(self, used_dataset_id_value, result_id_value):
         """Connect UsedDataset to Result"""
-        return self.__connect_with_relationship(self.used_dataset_type, used_dataset_id_value, self.result_type, result_id_value, self.connect_used_dataset_result)
+        return self.__connect_with_relationship(self.used_dataset_type, self.used_dataset_id, used_dataset_id_value, self.result_type, self.result_id, result_id_value, self.connect_used_dataset_result)
 
 
     def __connect_used_analyze_model_to_result(self, used_analyze_model_id_value, result_id_value):
         """Connect UsedAnalyzeModel to Result"""
-        return self.__connect_with_relationship(self.used_analyze_model_type, used_analyze_model_id_value, self.result_type, result_id_value, self.connect_used_analyze_model_result)
+        return self.__connect_with_relationship(self.used_analyze_model_type, self.used_analyze_model_id, used_analyze_model_id_value, self.result_type, self.result_id, result_id_value, self.connect_used_analyze_model_result)
     
 
     def __connect_used_data_model_to_result(self, used_data_model_id_value, result_id_value):
         """Connect UsedDataModel to Result"""
-        return self.__connect_with_relationship(self.used_data_model_type, used_data_model_id_value, self.result_type, result_id_value, self.connect_used_data_model_result)
+        return self.__connect_with_relationship(self.used_data_model_type, self.used_data_model_id, used_data_model_id_value, self.result_type, self.result_id, result_id_value, self.connect_used_data_model_result)
     
 
     def __connect_used_dataset_to_used_data_model(self, used_dataset_id_value, used_data_model_id_value):
         """Connect UsedDataset to UsedDataModel"""
-        return self.__connect_with_relationship(self.used_dataset_type, used_dataset_id_value, self.used_data_model_type, used_data_model_id_value, self.connect_used_dataset_used_data_model)
+        return self.__connect_with_relationship(self.used_dataset_type, self.used_dataset_id, used_dataset_id_value, self.used_data_model_type, self.used_data_model_id, used_data_model_id_value, self.connect_used_dataset_used_data_model)
     
 
     def __connect_used_dataset_to_used_analyze_model(self, used_dataset_id_value, used_analyze_model_id_value):
         """Connect UsedDataset to UsedAnalyzeModel"""
-        return self.__connect_with_relationship(self.used_dataset_type, used_dataset_id_value, self.used_analyze_model_type, used_analyze_model_id_value, self.connect_used_dataset_used_analyze_model)
+        return self.__connect_with_relationship(self.used_dataset_type, self.used_dataset_id, used_dataset_id_value, self.used_analyze_model_type, self.used_analyze_model_id, used_analyze_model_id_value, self.connect_used_dataset_used_analyze_model)
 
     
     ### Global settings

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -214,12 +214,7 @@ class Database:
         if not self.__does_node_exist(type, id_type, id_value):
             return False
         
-        # is new data datetime
-        try:
-            datetime.strptime(new_data, "%Y-%m-%dT%H:%M:%S")
-        except:
-            id_value = str(id_value)
-
+        id_value = str(id_value)
         query_string = (
             "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) "
             "SET n." + property_name + " = $old_data" 
@@ -279,7 +274,23 @@ class Database:
             return None
 
 
+    def __lookup_nodes(self, type, id_type, id_value, property_name):
+        """return nodes with (id, property_name) combo or None if nothing was found"""
+        id_value = str(id_value)
+        query_string = (
+            "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) "
+            "RETURN n." + property_name + " AS " + property_name
+        )
 
+        records, summary, keys = self.__driver.execute_query(
+            query_string,
+            database_= self.__name,
+        )
+        
+        try:
+            return next(iter(records)).data()[property_name]
+        except:
+            return None
         
         
     def __delete_node_with_connections(self, type, id_type, id_value, exclude_relationships = None):

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -394,6 +394,32 @@ class database:
     def delete_dataset(self, id_value):
         """Delete Dataset node"""
         return self.__delete_node(self.dataset_type, self.dataset_id, id_value)
+    
+
+    ### DataModel
+    def add_data_model_node(self, id_value):
+        """Create DataModel node. Avoids duplicates."""
+        return self.__add_node(self.data_model_type, self.data_model_id, id_value)
+
+
+    def set_data_model_property(self, id_value, property_name, new_data):
+        """Set DataModel property. Creates/overwrites current data.""" 
+        return self.__set_node_property(self.data_model_type, self.data_model_id, id_value, property_name, new_data)
+    
+        
+    def remove_data_model_property(self, id_value, property_name):
+        """Removes specific DataModel property data (and property)""" 
+        return self.__remove_property(self.data_model_type, self.data_model_id, id_value, property_name)
+
+
+    def lookup_data_model_property(self, id_value, property_name):
+        """Return data of specific property from DataModel""" 
+        return self.__lookup_node_property(self.data_model_type, self.data_model_id, id_value, property_name)
+    
+
+    def delete_data_model(self, id_value):
+        """Delete DataModel node""" 
+        return self.__delete_node_with_connections(self.data_model_type, self.data_model_id, id_value)
 
    
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -479,5 +479,9 @@ class database:
         return_h = self.__connect_used_dataset_to_used_data_model(used_dataset_id_value, used_data_model_id_value)
 
         return "result node created"
+    
+    def delete_result(self, id_value):
+        """Delete Result node""" 
+        return self.__delete_node_with_connections(self.result_type, self.result_id, id_value)
 
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -45,7 +45,7 @@ class database:
 
         self.connect_dataset_data_model = 'USED_FOR_TRAINING'
         self.connect_dataset_analyze_model = 'USED_FOR_TRAINING'
-                
+
         self.connect_dataset_project = 'ANALYZED_IN'
         self.connect_result_project = 'BELONGS_TO'
         self.connect_data_model_project = 'ACTIVE_IN'
@@ -374,5 +374,34 @@ class database:
         return self.__delete_node_with_connections(self.project_type, self.project_id, id_value, self.project_exclusion)
     
 
+    ### Result
+    # Todo: not needing to put id values(bad dupes), accept multiple relationships and accept no relationships
+    def add_result_node(self, result_id_value, project_id_value, analyze_model_id_value, used_analyze_model_id_value, used_dataset_id_value, used_data_model_id_value):
+        """Create Result node with all the connected information."""
+        return_a = self.__add_node(self.result_type, self.result_id, result_id_value)
+        return_b = self.__connect_result_to_project(result_id_value, project_id_value)
+        # search connected Dataset, make a copy of that and connect it
+        project_dataset_id_value = self.__lookup_connected_node_property(self.project_type, self.project_id, project_id_value, self.connect_dataset_project, self.dataset_id)
+        return_e = self.__copy_node(self.dataset_type, self.dataset_id, project_dataset_id_value, self.used_dataset_type, self.used_dataset_id, used_dataset_id_value)
+        return_f = self.__connect_used_dataset_to_result(used_dataset_id_value, result_id_value)
+
+        # make a copy of AnalyzeModel and connect it
+        return_c = self.__copy_node(self.analyze_model_type, analyze_model_id_value, self.used_analyze_model_type, self.used_analyze_model_id, used_analyze_model_id_value)
+        return_d = self.__connect_used_analyze_model_to_result(used_analyze_model_id_value, result_id_value)
+        # search connected Dataset, make a copy of that and connect it
+        analyze_model_dataset_id_value = self.__lookup_connected_node_property(self.analyze_model_type, self.analyze_model_id, analyze_model_id_value, self.connect_dataset_analyze_model, self.dataset_id)
+        return_e = self.__copy_node(self.dataset_type, self.dataset_id, analyze_model_dataset_id_value, self.used_dataset_type, self.used_dataset_id, used_dataset_id_value)
+        return_f = self.__connect_used_dataset_to_used_analyze_model(used_dataset_id_value, used_analyze_model_id_value)
+
+        # search connected DataModel, make a copy of that and connect it
+        project_data_model_id_value = self.__lookup_connected_node_property(self.project_type, self.project_id, project_id_value, self.connect_data_model_project, self.data_model_id)
+        return_e = self.__copy_node(self.data_model_type, self.data_model_id, project_data_model_id_value, self.used_data_model_type, self.used_data_model_id, used_data_model_id_value)
+        return_f = self.__connect_used_data_model_to_result(used_data_model_id_value, result_id_value)
+        # search connected Dataset, make a copy of that and connect it
+        data_model_dataset_id_value = self.__lookup_connected_node_property(self.data_model_type, self.data_model_id, project_data_model_id_value, self.connect_dataset_data_model, self.dataset_id)
+        return_g = self.__copy_node(self.dataset_type, self.dataset_id, data_model_dataset_id_value, self.used_dataset_type, self.used_dataset_id, used_dataset_id_value)
+        return_h = self.__connect_used_dataset_to_used_data_model(used_dataset_id_value, used_data_model_id_value)
+
+        return "result node created"
 
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -8,7 +8,7 @@ class database:
         Setup types and identifier names according to database design.
         """
         self.__driver = GraphDatabase.driver(os.getenv('NEO4J_URL'), auth=(os.getenv('NEO4J_USER'), os.getenv('NEO4J_PASSWORD')))
-        self.__name = 'neo4j'     # database name
+        self.__name = os.getenv('NEO4J_DB_NAME')
 
         self.__global_settings_type = 'Settings'
         self.__global_settings_id = 'name'
@@ -42,14 +42,18 @@ class database:
         self.__used_analyze_model_type = 'UsedAnalyzeModel'
         self.__used_analyze_model_id = 'id'
         
-
+        # model related connections
         self.__connect_dataset_data_model = 'USED_FOR_TRAINING'
         self.__connect_dataset_analyze_model = 'USED_FOR_TRAINING'
 
+        # project related connections
         self.__connect_dataset_project = 'ANALYZED_IN'
         self.__connect_result_project = 'BELONGS_TO'
+
+        # model(s) used to construct the data structure in project, used for making result node (complicated way)
         self.__connect_data_model_project = 'ACTIVE_IN'
 
+        # result node related
         self.__connect_used_analyze_model_result = 'USED_IN_ANALYSIS'
         self.__connect_used_data_model_result = 'USED_IN_ANALYSIS'
         self.__connect_used_dataset_result = 'USED_IN_ANALYSIS'

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -342,11 +342,15 @@ def db_delete_dataset(node_id):
 """
 Connection functions
 """
-# Connect from dataset node to subject area node
+# Connect from Dataset node to subject area node
 def db_connect_dataset_to_subject_area(dataset_node_id, subject_area_node_name):
-    return db_connect_with_relationship('Dataset', dataset_node_id, 'SubjectArea', subject_area_node_name, 'DATA_ANALYSATION')
+    return db_connect_with_relationship('Dataset', dataset_node_id, 'SubjectArea', subject_area_node_name, 'ANALYZED_IN')
 
-# Connect from dataset node to model node
-def db_connect_dataset_to_model(dataset_node_id, model_node_name):
-    return db_connect_with_relationship('Dataset', dataset_node_id, 'Model', model_node_name, 'MODEL_CREATION')
+# Connect from Dataset node to DataModel node
+def db_connect_dataset_to_data_model(dataset_node_id, model_node_name):
+    return db_connect_with_relationship('Dataset', dataset_node_id, 'DataModel', model_node_name, 'USED_FOR_TRAINING')
+
+# Connect from Dataset node to AnalyzeModel node
+def db_connect_dataset_to_analyze_model(dataset_node_id, model_node_name):
+    return db_connect_with_relationship('Dataset', dataset_node_id, 'AnalyzeModel', model_node_name, 'USED_FOR_TRAINING')
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -92,6 +92,10 @@ class database:
         Create a node with specific node-type, id-type and it's value.
         Doesn't give False when node exists
         """
+        # check if node already exists
+        if self.__does_node_exist(type, id_type, id_value):
+            return False
+
         id_value = str(id_value)
         query_string = "MERGE (n:" + type + " {" + id_type + ": $value})"
 
@@ -111,6 +115,10 @@ class database:
         """return True when query succeeded
         Set specific node property with new data.
         """
+        # check if node exists
+        if not self.__does_node_exist(type, id_type, id_value):
+            return False
+
         id_value = str(id_value)
         query_string = (
             "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) "
@@ -175,6 +183,10 @@ class database:
         """return True when query succeeded
         Delete node and all related nodes with incoming connections 0..n deep. Possible to exclude relationships.
         """
+        # check if node exists
+        if not self.__does_node_exist(type, id_type, id_value):
+            return False
+
         id_value = str(id_value)
 
         # Supporting: None, string list, single string
@@ -220,6 +232,10 @@ class database:
         """return True when query succeeded
         Delete a node and it's connections
         """
+        # check if node exists
+        if not self.__does_node_exist(type, id_type, id_value):
+            return False
+
         id_value = str(id_value)
         query_string = (
             "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) "
@@ -241,6 +257,10 @@ class database:
         """return True when query succeeded
         Remove node property.
         """
+        # check if property exists
+        if not self.__does_property_exist(type, id_type, id_value, property_name):
+            return False
+
         id_value = str(id_value)
         query_string = (
             "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) "
@@ -262,6 +282,14 @@ class database:
         """return True when query succeeded
         Connect node a to node b with specific relationship. (a)-[rel]->(b).
         """
+        # check if node a exists
+        if not self.__does_node_exist(type_a, id_type_a, id_value_a):
+            return False
+        
+        # check if node b exists
+        if not self.__does_node_exist(type_b, id_type_b, id_value_b):
+            return False
+
         id_value_a = str(id_value_a)
         id_value_b = str(id_value_b)
         query_string = (

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -492,7 +492,7 @@ class Database:
                 query_string,
                 database_= self.__name,
             )
-        
+
             if not records:
                 return False
             else:
@@ -888,7 +888,7 @@ class Database:
         return self.__set_node_property(self.__result_blueprint_type, self.__result_blueprint_id, id_value, property_name.value, new_data)
 
 
-    def remove_project_property(self, id_value, property_name: NodeProperties.ResultBlueprint):
+    def remove_result_blueprint_property(self, id_value, property_name: NodeProperties.ResultBlueprint):
         """Removes specific Project property data (and property)""" 
         return self.__remove_property(self.__result_blueprint_type, self.__result_blueprint_id, id_value, property_name.value)
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,14 +1,19 @@
 """
 Database functions:
 Debug purpose:
-db_clear() , wipes database clean
-db_show_all() , prints the whole database in console
+debug_db_clear() , wipes database clean
+debug_db_show_all() , prints the whole database in console
 
 Helper functions:
 db_add_node(node_type, node_name) , create node with a name attribute
-db_modify_node_data(node_type, node_name, property_name, new_data) , modify property data
+db_modify_node_data(node_type, node_name, property_name, new_data) , modify one property data
 db_lookup_whole_node(node_type, node_name) , lookup and return all properties from the node
-db_lookup_node_property(node_type, node_name, property_name) , lookup and return single 
+db_lookup_node_property(node_type, node_name, property_name) , lookup and return single property data
+db_delete_node_with_connections(node_type, node_name) , deletes node and all connected nodes 0..n deep
+db_delete_node(node_type, node_name) , delete certain node type with certain name
+db_delete_property(node_type, node_name, property_name) , delete specific property data
+db_connect_with_relationship(node_type_a, node_name_a, node_type_b, node_name_b, relationship_type) , connect node a -> node b with relationship type
+
 
 Global settings:
 db_add_settings_node() , creates settings node
@@ -17,12 +22,36 @@ db_lookup_settings_data(property_name) , lookup specific property data
 db_delete_settings_data(property_name) , delete specific property data (also delete property)
 db_delete_settings() , deletes settings with all it's related content.
 
-Subject area settings:
+Subject area:
 db_add_subject_area_node(node_name) , creates subject area node of specific name
 db_modify_subject_area_data(node_name, property_name, data) , modify specific property with specific data
 db_lookup_subject_area_data(node_name, property_name) , lookup specific property data
 db_delete_subject_area_data(node_name, property_name) , delete specific property data (also delete property)
-db_delete_subject_area(node_name) , deletes specific subject area with all it's related content.
+db_delete_subject_area(node_name) , deletes SubjectArea-node and it's Dataset-nodes
+
+Result:
+db_add_result_node(node_id)
+db_modify_result_data(node_id, property_name, new_data)
+db_delete_result_data(node_id, property_name)
+db_lookup_result_data(node_id, property_name)
+db_delete_result(node_id) , only deletes node
+
+Model:
+db_add_model_node(node_name)
+db_modify_model_data(node_name, property_name, new_data)
+db_delete_model_data(node_name, property_name)
+db_lookup_model_data(node_name, property_name)
+db_delete_model(node_name) , deletes Model-node and it's Dataset-nodes
+
+Dataset:
+db_add_dataset_node(node_id)
+db_modify_dataset_data(node_id, new_data)
+db_lookup_dataset_data(node_id)
+db_delete_dataset(node_id) , only deletes Dataset-node
+
+Connections:
+db_connect_dataset_to_subject_area(dataset_node_id, subject_area_node_name) , connect dataset -> subject area
+db_connect_dataset_to_model(dataset_node_id, model_node_name) , connect dataset -> model
 """
 
 from neo4j import GraphDatabase
@@ -90,6 +119,7 @@ def db_modify_node_data(node_type, node_name, property_name, new_data):
 
 # Lookup node and return all it's data
 def db_lookup_whole_node(node_type, node_name):
+    # define query string within python, because driver doesn't allow property types being a variable
     query_string = "MATCH (n:" + node_type + " {name: '" + node_name + "'}) RETURN n"
     
     records, summary, keys = driver.execute_query(

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -5,6 +5,7 @@ import os
 
 class NodeProperties:
     """All allowed property names for each node type.
+    Check Database class init for reserved names for identifier usage before adding new property names.
     """
     class GlobalSettings(Enum):
         # Settings

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -2,7 +2,7 @@ from neo4j import GraphDatabase
 from dotenv import load_dotenv
 import os
 
-class database:
+class Database:
     def __init__(self) -> None:
         """Start up database connection.
         Setup types and identifier names according to database design v3.

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -205,7 +205,6 @@ def db_lookup_settings_data(property_name):
 def db_delete_settings():
     return db_delete_node('Settings', settings_node_name)
 
-
 """
 User settings functions
 """
@@ -228,7 +227,6 @@ def db_lookup_user_settings_data(user_name, property_name):
 # Deletes global UserSettings with all it's related content.
 def db_delete_user_settings(user_name):
     return db_delete_node('UserSettings', user_name)
-
 
 """
 Subject area functions
@@ -277,27 +275,50 @@ def db_delete_result(node_id):
     return db_delete_node('Result', node_id)
 
 """
-Model functions
+DataModel functions
+"""
+# Create new DataModel-node with specific name. Avoids duplicates.
+def db_add_data_model_node(node_name):
+    return db_add_node('DataModel', node_name)
+
+# Modify DataModel-node's properties. Replaces specific property with new data.
+def db_modify_data_model_data(node_name, property_name, new_data):
+    return db_modify_node_data('DataModel', node_name, property_name, new_data)
+
+# Removes specific DataModel property data (and property).
+def db_delete_data_model_data(node_name, property_name):
+    return db_delete_property('DataModel', node_name, property_name)
+
+# Return data of specific property from DataModel-node
+def db_lookup_data_model_data(node_name, property_name):
+    return db_lookup_node_property('DataModel', node_name, property_name)
+
+# Deletes specific DataModel with all it's related content.
+def db_delete_data_model(node_name):
+    return db_delete_node_with_connections('DataModel', node_name)
+
+"""
+AnalyzeModel functions
 """
 # Create new Model-node with specific name. Avoids duplicates.
-def db_add_model_node(node_name):
-    return db_add_node('Model', node_name)
+def db_add_analyze_model_node(node_name):
+    return db_add_node('AnalyzeModel', node_name)
 
 # Modify Model-node's properties. Replaces specific property with new data.
-def db_modify_model_data(node_name, property_name, new_data):
-    return db_modify_node_data('Model', node_name, property_name, new_data)
+def db_modify_analyze_model_data(node_name, property_name, new_data):
+    return db_modify_node_data('AnalyzeModel', node_name, property_name, new_data)
 
 # Removes specific Model property data (and property).
-def db_delete_model_data(node_name, property_name):
-    return db_delete_property('Model', node_name, property_name)
+def db_delete_analyze_model_data(node_name, property_name):
+    return db_delete_property('AnalyzeModel', node_name, property_name)
 
 # Return data of specific property from Model-node
-def db_lookup_model_data(node_name, property_name):
-    return db_lookup_node_property('Model', node_name, property_name)
+def db_lookup_analyze_model_data(node_name, property_name):
+    return db_lookup_node_property('AnalyzeModel', node_name, property_name)
 
 # Deletes specific Model with all it's related content.
-def db_delete_model(node_name):
-    return db_delete_node_with_connections('Model', node_name)
+def db_delete_analyze_model(node_name):
+    return db_delete_node_with_connections('AnalyzeModel', node_name)
 
 """
 Dataset functions

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -216,4 +216,5 @@ class database:
     
 
     def delete_global_settings(self):
+        """Delete global settings node""" 
         return self.__delete_node(self.global_settings_type, self.global_settings_id, self.global_settings_id_value)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -226,6 +226,25 @@ class database:
         )
         return "Copied " + type + "(" + id_value + ") to " + node_type_new + "(" + id_value_new + ")"
     
+    def __lookup_connected_node_property(self, type_a, id_type_a, id_value_a, relationship_type, property_name):
+        """return node property data or error string
+        Lookup individual property value from a neighboring node that is connected by certain relationship
+        """
+        id_value_a = str(id_value_a)
+        query_string = "MATCH (a:" + type_a + " {" + id_type_a + ": '" + id_value_a + "'}) <- [:" + relationship_type + "] - (b) RETURN b." + property_name + " AS " + property_name
+        
+        records, summary, keys = self.driver.execute_query(
+            query_string,
+            database_= self.name,
+        )
+        
+        try:
+            return next(iter(records)).data()[property_name]
+        except:
+            return "ERROR: Property not found"
+
+
+    
     ### Connections
     def connect_dataset_to_data_model(self, dataset_id_value, data_model_id_value):
         """Connect Dataset to DataModel"""

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,393 +1,165 @@
-"""
-Database functions:
-Debug purpose:
-debug_db_clear() , wipes database clean
-debug_db_show_all() , prints the whole database in console
-
-Helper functions:
-db_add_node(node_type, node_name) , create node with a name attribute
-db_modify_node_data(node_type, node_name, property_name, new_data) , modify one property data
-db_lookup_whole_node(node_type, node_name) , lookup and return all properties from the node
-db_lookup_node_property(node_type, node_name, property_name) , lookup and return single property data
-db_delete_node_with_connections(node_type, node_name) , deletes node and all connected nodes 0..n deep
-db_delete_node(node_type, node_name) , delete certain node type with certain name
-db_delete_property(node_type, node_name, property_name) , delete specific property data
-db_connect_with_relationship(node_type_a, node_name_a, node_type_b, node_name_b, relationship_type) , connect node a -> node b with relationship type
-
-
-Global settings:
-db_add_settings_node() , creates settings node
-db_modify_settings_data(property_name, data) , modifies specific property with specific data
-db_lookup_settings_data(property_name) , lookup specific property data
-db_delete_settings_data(property_name) , delete specific property data (also delete property)
-db_delete_settings() , deletes settings node.
-
-Subject area:
-db_add_subject_area_node(node_name) , creates subject area node of specific name
-db_modify_subject_area_data(node_name, property_name, data) , modify specific property with specific data
-db_lookup_subject_area_data(node_name, property_name) , lookup specific property data
-db_delete_subject_area_data(node_name, property_name) , delete specific property data (also delete property)
-db_delete_subject_area(node_name) , deletes SubjectArea-node and it's Dataset-nodes
-
-Result:
-db_add_result_node(node_id)
-db_modify_result_data(node_id, property_name, new_data)
-db_delete_result_data(node_id, property_name)
-db_lookup_result_data(node_id, property_name)
-db_delete_result(node_id) , only deletes node
-
-Model:
-db_add_model_node(node_name)
-db_modify_model_data(node_name, property_name, new_data)
-db_delete_model_data(node_name, property_name)
-db_lookup_model_data(node_name, property_name)
-db_delete_model(node_name) , deletes Model-node and it's Dataset-nodes
-
-Dataset:
-db_add_dataset_node(node_id)
-db_modify_dataset_data(node_id, new_data)
-db_lookup_dataset_data(node_id)
-db_delete_dataset(node_id) , only deletes Dataset-node
-
-Connections:
-db_connect_dataset_to_subject_area(dataset_node_id, subject_area_node_name) , connect dataset -> subject area
-db_connect_dataset_to_model(dataset_node_id, model_node_name) , connect dataset -> model
-"""
-
 from neo4j import GraphDatabase
 from dotenv import load_dotenv
 import os
 
-driver = GraphDatabase.driver(os.getenv('NEO4J_URL'), auth=(os.getenv('NEO4J_USER'), os.getenv('NEO4J_PASSWORD')))
+class database:
+    def __init__(self) -> None:
+        self.driver = GraphDatabase.driver(os.getenv('NEO4J_URL'), auth=(os.getenv('NEO4J_USER'), os.getenv('NEO4J_PASSWORD')))
+        self.name = 'neo4j'     # database name
+        self.global_settings_name = 'Global'
 
-# name of the global settings node
-settings_node_name = 'Global'
 
-# database name (default = 'neo4j')
-database_name = 'neo4j'
+    def debug_clear_all(self):
+        """return useful string message
+        DEBUG: Clear the whole database
+        """
+        self.driver.execute_query(
+            "MATCH (n) DETACH DELETE n",
+            database_= self.name,
+        )
+        return "Database cleared"
 
-"""
-Debug functions
-"""
-# Wipe database clean, deletes all data
-def debug_db_clear():
-    driver.execute_query(
-        "MATCH (n) DETACH DELETE n",
-        database_= database_name,
-    )
-    return "Database cleared"
 
-# Show the whole database, print it out in console.
-def debug_db_show_all():
-    records, summary, keys = driver.execute_query(
-        "MATCH (n) RETURN n",
-        database_= database_name,
-    )
+    def debug_show_all(self):
+        """return useful string message
+        DEBUG: Print the whole database in console.
+        """
+        records, summary, keys = self.driver.execute_query(
+            "MATCH (n) RETURN n",
+            database_= self.name,
+        )
+        
+        for record in records:
+            print(record)
+
+        return "Whole database printed out in console"
     
-    for record in records:
-        print(record)
 
-    return "Whole database printed out in console"
+    def __add_node(self, type, id_type, id_value):
+        """return useful string message
+        Create a node with specific node-type, id-type and it's value. Can't duplicate.
+        """
+        query_string = "MERGE (n:" + type + " {" + id_type + ": $value})"
 
+        self.driver.execute_query(
+            query_string,
+            value = id_value,
+            database_= self.name,
+        )
+        return "Added node: " + type + "." + id_type + "(" + id_value + ")"
+            
 
-"""
-Universal helper functions
-"""
-# Create node with specific type and name
-def db_add_node(node_type, node_name):
-    # define query string within python, because driver doesn't allow property types being a variable
-    query_string = "MERGE (n:" + node_type + " {name: $name})"
+    def __modify_node_data(self, type, id_type, id_value, property_name, new_data):
+        """return useful string message
+        Replaces specific node property with new data.
+        """
+        query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) SET n." + property_name + " = $old_data"
 
-    driver.execute_query(
-        query_string,
-        name = node_name,
-        database_= database_name,
-    )
-    return "Added node: " + node_type + " with a name:" + node_name
-
-# Modify node properties. Replaces specific property with new data.
-def db_modify_node_data(node_type, node_name, property_name, new_data):
-    # define query string within python, because driver doesn't allow property types being a variable
-    query_string = "MATCH (n:" + node_type + " {name: '" + node_name + "'}) SET n." + property_name + " = $old_data"
-
-    driver.execute_query(
-        query_string,
-        old_data = new_data,
-        database_= database_name,
-    )
-    return "Modified data: " + node_type + "("+ node_name +")."+ property_name
-
-# Lookup node and return all it's data
-def db_lookup_whole_node(node_type, node_name):
-    # define query string within python, because driver doesn't allow property types being a variable
-    query_string = "MATCH (n:" + node_type + " {name: '" + node_name + "'}) RETURN n"
+        self.driver.execute_query(
+            query_string,
+            old_data = new_data,
+            database_= self.name,
+        )
+        return "Modified data: " + type + "("+ id_value +")."+ property_name
     
-    records, summary, keys = driver.execute_query(
-        query_string,
-        database_= database_name,
-    )
-    return next(iter(records)).data()
 
-# Lookup individual property value from a node
-def db_lookup_node_property(node_type, node_name, property_name):
-    query_string = "MATCH (n:" + node_type + " {name: '" + node_name + "'}) RETURN n." + property_name + " AS " + property_name
+    def __lookup_whole_node(self, type, id_type, id_value):
+        """return whole node data or error string
+        Lookup a node and return all it's data
+        """
+        query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) RETURN n"
+        
+        records, summary, keys = self.driver.execute_query(
+            query_string,
+            database_= self.name,
+        )
+
+        try:
+            return next(iter(records)).data()
+        except:
+            return "ERROR: Node not found"
+
+
+    def __lookup_node_property(self, type, id_type, id_value, property_name):
+        """return node property data or error string
+        Lookup individual property value from a node
+        """
+        query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) RETURN n." + property_name + " AS " + property_name
+        
+        records, summary, keys = self.driver.execute_query(
+            query_string,
+            database_= self.name,
+        )
+        
+        try:
+            return next(iter(records)).data()[property_name]
+        except:
+            return "ERROR: Property not found"
+        
+        
+    def __delete_node_with_connections(self, type, id_type, id_value, exclude_relationships = None):
+        """return useful string message
+        Delete node and all related nodes with incoming connections 0..n deep. Possible to exclude relationships.
+        """
+        if exclude_relationships == None:
+            query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) <- [*0..] - (d) WITH DISTINCT d DETACH DELETE d,n"
+        if isinstance(exclude_relationships,list):
+            query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) <- [r:*0..] - (d) WHERE NOT type(r) IN "+ exclude_relationships + " WITH DISTINCT d DETACH DELETE d,n"
+        else:
+            query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) <- [r:*0..] - (d) WHERE NOT type(r) IN ['"+ exclude_relationships + "'] WITH DISTINCT d DETACH DELETE d,n"
+        
+        self.driver.execute_query(
+            query_string,
+            database_= self.name,
+        )
+        return type + "(" + id_value + ") deleted with connections"
+
+    def __delete_node(self, type, id_type, id_value):
+        """return useful string message
+        Delete a node and it's connections
+        """
+        query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) DETACH DELETE n"
+        
+        self.driver.execute_query(
+            query_string,
+            database_= self.name,
+        )
+        return type + "(" + id_value + ") deleted"
     
-    records, summary, keys = driver.execute_query(
-        query_string,
-        database_= database_name,
-    )
-    return next(iter(records)).data()[property_name]
 
-# Delete node and all related nodes 0..n deep
-def db_delete_node_with_connections(node_type, node_name):
-    # define query string within python, because driver doesn't allow property types being a variable
-    query_string = "MATCH (n:" + node_type + " {name: '" + node_name + "'}) - [*0..] - (d) WITH DISTINCT d DETACH DELETE d"
+    def __delete_property(self, type, id_type, id_value, property_name):
+        """return useful string message
+        Delete node property.
+        """
+        query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) REMOVE n." + property_name
+        
+        self.driver.execute_query(
+            query_string,
+            database_= self.name,
+        )
+        return "Deleted: " + type + "(" + id_value + ")." + property_name
     
-    driver.execute_query(
-        query_string,
-        database_= database_name,
-    )
-    return node_type + "(" + node_name + ") deleted with connections"
 
-# Delete node and it's connections
-def db_delete_node(node_type, node_name):
-    # define query string within python, because driver doesn't allow property types being a variable
-    query_string = "MATCH (n:" + node_type + " {name: '" + node_name + "'}) DETACH DELETE n"
+    def __connect_with_relationship(self, type_a, id_type_a, id_value_a, type_b, id_type_b, id_value_b, relationship_type):
+        """return useful string message
+        Connect node a to node b with specific relationship. (a)-[rela]->(b).
+        """
+        query_string = "MATCH (a:" + type_a + " {" + id_type_a + ": '" + id_value_a + "'}) MATCH (b:" + type_b + " {" + id_type_b + ": '" + id_value_b + "'}) MERGE (a)-[:" + relationship_type + "]->(b)"
+
+        self.driver.execute_query(
+            query_string,
+            database_= self.name,
+        )
+        return "Connected: " + type_a + "(" + id_value_a + ")-[" + relationship_type + "]>" + type_b + "(" + id_value_b + ")"
     
-    driver.execute_query(
-        query_string,
-        database_= database_name,
-    )
-    return node_type + "(" + node_name + ") deleted"
+    def __copy_node(self, type, id_type, id_value, node_type_new, id_type_new, id_value_new):
+        """return useful string message
+        Copy node into a new node type.
+        """
+        query_string = "MATCH (n:" + type + " {" + id_type + ": '" + id_value + "'}) MERGE (m:" + node_type_new + " {" + id_type_new + ": '" + id_value_new + "'}) SET m = properties(n)"
 
-# Delete node property
-def db_delete_property(node_type, node_name, property_name):
-    # define query string within python, because driver doesn't allow property types being a variable
-    query_string = "MATCH (n:" + node_type + " {name: '" + node_name + "'}) REMOVE n." + property_name
-    
-    driver.execute_query(
-        query_string,
-        database_= database_name,
-    )
-    return "Deleted: " + node_type + "(" + node_name + ")." + property_name
-
-def db_connect_with_relationship(node_type_a, node_name_a, node_type_b, node_name_b, relationship_type):
-    # define query string within python, because driver doesn't allow property types being a variable
-    query_string = "MATCH (n:" + node_type_a + " {name: '" + node_name_a + "'}) MATCH (m:" + node_type_b + " {name: '" + node_name_b + "'}) MERGE (n)-[:" + relationship_type + "]->(m)"
-
-    driver.execute_query(
-        query_string,
-        database_= database_name,
-    )
-    return "Connected: " + node_type_a + "(" + node_name_a + ")->" + node_type_b + "(" + node_name_b + ")"
-
-
-def db_copy_node(node_type, new_node_type, id_type, id_value):
-    # define query string within python, because driver doesn't allow property types being a variable
-    query_string = "MATCH (n:" + node_type + " {" + id_type + ": '" + id_value + "'}) MERGE (m:" + new_node_type + " {" + id_type + ": '" + id_value + "'}) SET m = properties(n)"
-
-    driver.execute_query(
-        query_string,
-        database_= database_name,
-    )
-    return "Copied " + node_type + "(" + id_value + ") to " + new_node_type + "(" + id_value + ")"
-
-
-"""
-Global settings functions
-"""
-# Create new Settings-node. Avoids duplicates.
-def db_add_settings_node():
-    return db_add_node('Settings', settings_node_name)
-
-# Modify Settings properties. Replaces specific property with new data.
-def db_modify_settings_data(property_name, new_data):
-    return db_modify_node_data('Settings', settings_node_name, property_name, new_data)
-
-# Removes specific Settings property data (and property).
-def db_delete_settings_data(property_name):
-    return db_delete_property('Settings', settings_node_name, property_name)
-
-# Return data of specific property from settings
-def db_lookup_settings_data(property_name):
-    return db_lookup_node_property('Settings', settings_node_name, property_name)
-
-# Deletes settings with all it's related content.
-def db_delete_settings():
-    return db_delete_node('Settings', settings_node_name)
-
-"""
-User settings functions
-"""
-# Create new UserSettings-node. Avoids duplicates.
-def db_add_user_settings_node(user_name):
-    return db_add_node('UserSettings', user_name)
-
-# Modify UserSettings properties. Replaces specific property with new data.
-def db_modify_user_settings_data(user_name, property_name, new_data):
-    return db_modify_node_data('UserSettings', user_name, property_name, new_data)
-
-# Removes specific UserSettings property data (and property).
-def db_delete_user_settings_data(user_name, property_name):
-    return db_delete_property('UserSettings', user_name, property_name)
-
-# Return data of specific property from UserSettings
-def db_lookup_user_settings_data(user_name, property_name):
-    return db_lookup_node_property('UserSettings', user_name, property_name)
-
-# Deletes UserSettings with all it's related content.
-def db_delete_user_settings(user_name):
-    return db_delete_node('UserSettings', user_name)
-
-"""
-Project functions
-"""
-# Create new Project-node with specific name. Avoids duplicates.
-def db_add_project_node(node_name):
-    return db_add_node('Project', node_name)
-
-# Modify Project-node's properties. Replaces specific property with new data.
-def db_modify_project_data(node_name, property_name, new_data):
-    return db_modify_node_data('Project', node_name, property_name, new_data)
-
-# Removes specific Project property data (and property).
-def db_delete_project_data(node_name, property_name):
-    return db_delete_property('Project', node_name, property_name)
-
-# Return data of specific property from Project-node
-def db_lookup_project_data(node_name, property_name):
-    return db_lookup_node_property('Project', node_name, property_name)
-
-# Deletes specific Project with all it's related content.
-def db_delete_project(node_name):
-    return db_delete_node_with_connections('Project', node_name)
-
-"""
-Result functions
-todo:
-- delete all connected UsedInAnalysis nodes too
-"""
-# Create new Result-node with specific name. Avoids duplicates.
-# Connect it with project
-def db_add_result_node(result_node_id, project_node_name, analyze_model_name):
-    return_a = db_add_node('Result', result_node_id)
-    return_b = db_connect_result_to_project(result_node_id, project_node_name)
-    return_c = db_add_used_analyze_model_node(analyze_model_name, result_node_id)
-    return return_a + " and " + return_b + " and " + return_c
-
-# Modify Result-node's properties. Replaces specific property with new data.
-def db_modify_result_data(node_id, property_name, new_data):
-    return db_modify_node_data('Result', node_id, property_name, new_data)
-
-# Removes specific Result property data (and property).
-def db_delete_result_data(node_id, property_name):
-    return db_delete_property('Result', node_id, property_name)
-
-# Return data of specific property from Result-node
-def db_lookup_result_data(node_id, property_name):
-    return db_lookup_node_property('Result', node_id, property_name)
-
-# Deletes specific Result with all it's related content.
-def db_delete_result(node_id):
-    return db_delete_node('Result', node_id)
-
-"""
-DataModel functions
-"""
-# Create new DataModel-node with specific name. Avoids duplicates.
-def db_add_data_model_node(node_name):
-    return db_add_node('DataModel', node_name)
-
-# Modify DataModel-node's properties. Replaces specific property with new data.
-def db_modify_data_model_data(node_name, property_name, new_data):
-    return db_modify_node_data('DataModel', node_name, property_name, new_data)
-
-# Removes specific DataModel property data (and property).
-def db_delete_data_model_data(node_name, property_name):
-    return db_delete_property('DataModel', node_name, property_name)
-
-# Return data of specific property from DataModel-node
-def db_lookup_data_model_data(node_name, property_name):
-    return db_lookup_node_property('DataModel', node_name, property_name)
-
-# Deletes specific DataModel with all it's related content.
-def db_delete_data_model(node_name):
-    return db_delete_node_with_connections('DataModel', node_name)
-
-"""
-AnalyzeModel functions
-"""
-# Create new AnalyzeModel-node with specific name. Avoids duplicates.
-def db_add_analyze_model_node(node_name):
-    return db_add_node('AnalyzeModel', node_name)
-
-# Modify AnalyzeModel-node's properties. Replaces specific property with new data.
-def db_modify_analyze_model_data(node_name, property_name, new_data):
-    return db_modify_node_data('AnalyzeModel', node_name, property_name, new_data)
-
-# Removes specific AnalyzeModel property data (and property).
-def db_delete_analyze_model_data(node_name, property_name):
-    return db_delete_property('AnalyzeModel', node_name, property_name)
-
-# Return data of specific property from AnalyzeModel-node
-def db_lookup_analyze_model_data(node_name, property_name):
-    return db_lookup_node_property('AnalyzeModel', node_name, property_name)
-
-# Deletes specific AnalyzeModel with all it's related content.
-def db_delete_analyze_model(node_name):
-    return db_delete_node_with_connections('AnalyzeModel', node_name)
-
-"""
-UsedAnalyzeModel functions
-"""
-# Create new UsedAnalyzeModel from a copy of AnalyzeModel
-# Connect it with Result
-def db_add_used_analyze_model_node(model_node_name, result_node_name):
-    return_a = db_copy_node('AnalyzeModel','UsedAnalyzeModel', 'name', model_node_name)
-    return_b = db_connect_used_analyze_model_to_result(model_node_name, result_node_name)
-    return return_a + " and " + return_b
-
-
-db_copy_node
-"""
-Dataset functions
-"""
-# Create new Dataset-node with specific name. Avoids duplicates.
-def db_add_dataset_node(node_id):
-    return db_add_node('Dataset', node_id)
-
-# Modify Dataset-node's properties. Replaces data with new data.
-def db_modify_dataset_data(node_id, file_name):
-    return db_modify_node_data('Dataset', node_id, 'Filename', file_name)
-
-# Return data of specific property from Dataset-node
-def db_lookup_dataset_data(node_id):
-    return db_lookup_node_property('Dataset', node_id, 'Filename')
-
-# Deletes specific Dataset with all it's related content.
-def db_delete_dataset(node_id):
-    return db_delete_node('Dataset', node_id)
-
-"""
-Connection functions
-"""
-# Connect from Dataset node to project node
-def db_connect_dataset_to_project(dataset_node_id, project_node_name):
-    return db_connect_with_relationship('Dataset', dataset_node_id, 'Project', project_node_name, 'ANALYZED_IN')
-
-# Connect from Dataset node to DataModel node
-def db_connect_dataset_to_data_model(dataset_node_id, model_node_name):
-    return db_connect_with_relationship('Dataset', dataset_node_id, 'DataModel', model_node_name, 'USED_FOR_TRAINING')
-
-# Connect from Dataset node to AnalyzeModel node
-def db_connect_dataset_to_analyze_model(dataset_node_id, model_node_name):
-    return db_connect_with_relationship('Dataset', dataset_node_id, 'AnalyzeModel', model_node_name, 'USED_FOR_TRAINING')
-
-# Connect from UsedAnalyzeModel node to Result node
-def db_connect_used_analyze_model_to_result(model_node_name, result_node_name):
-    return db_connect_with_relationship('UsedAnalyzeModel', model_node_name, 'Result', result_node_name, 'USED_IN_ANALYSIS')
-
-# Connect from Result node to Project node
-def db_connect_result_to_project(result_node_name, project_node_name):
-    return db_connect_with_relationship('Result', result_node_name, 'Project', project_node_name, 'BELONGS_TO')
-
+        self.driver.execute_query(
+            query_string,
+            database_= self.name,
+        )
+        return "Copied " + type + "(" + id_value + ") to " + node_type_new + "(" + id_value_new + ")"

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -185,11 +185,11 @@ def db_connect_with_relationship(node_type_a, node_name_a, node_type_b, node_nam
 """
 Global settings functions
 """
-# Create new Settings-node named "Base". Avoids duplicates.
+# Create new Settings-node. Avoids duplicates.
 def db_add_settings_node():
     return db_add_node('Settings', settings_node_name)
 
-# Modify Settings (Base) properties. Replaces specific property with new data.
+# Modify Settings properties. Replaces specific property with new data.
 def db_modify_settings_data(property_name, new_data):
     return db_modify_node_data('Settings', settings_node_name, property_name, new_data)
 
@@ -197,7 +197,7 @@ def db_modify_settings_data(property_name, new_data):
 def db_delete_settings_data(property_name):
     return db_delete_property('Settings', settings_node_name, property_name)
 
-# Return data of specific property from settings (Base)
+# Return data of specific property from settings
 def db_lookup_settings_data(property_name):
     return db_lookup_node_property('Settings', settings_node_name, property_name)
 
@@ -209,25 +209,25 @@ def db_delete_settings():
 """
 User settings functions
 """
-# Create new Settings-node named "Base". Avoids duplicates.
-def db_add_user_settings_node():
-    return db_add_node('UserSettings', settings_node_name)
+# Create new UserSettings-node. Avoids duplicates.
+def db_add_user_settings_node(user_name):
+    return db_add_node('UserSettings', user_name)
 
-# Modify Settings (Base) properties. Replaces specific property with new data.
-def db_modify_user_settings_data(property_name, new_data):
-    return db_modify_node_data('UserSettings', settings_node_name, property_name, new_data)
+# Modify UserSettings properties. Replaces specific property with new data.
+def db_modify_user_settings_data(user_name, property_name, new_data):
+    return db_modify_node_data('UserSettings', user_name, property_name, new_data)
 
-# Removes specific Settings property data (and property).
-def db_delete_user_settings_data(property_name):
-    return db_delete_property('UserSettings', settings_node_name, property_name)
+# Removes specific UserSettings property data (and property).
+def db_delete_user_settings_data(user_name, property_name):
+    return db_delete_property('UserSettings', user_name, property_name)
 
-# Return data of specific property from settings (Base)
-def db_lookup_user_settings_data(property_name):
-    return db_lookup_node_property('UserSettings', settings_node_name, property_name)
+# Return data of specific property from UserSettings
+def db_lookup_user_settings_data(user_name, property_name):
+    return db_lookup_node_property('UserSettings', user_name, property_name)
 
-# Deletes global settings with all it's related content.
-def db_delete_user_settings():
-    return db_delete_node('UserSettings', settings_node_name)
+# Deletes global UserSettings with all it's related content.
+def db_delete_user_settings(user_name):
+    return db_delete_node('UserSettings', user_name)
 
 
 """

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -193,5 +193,27 @@ class database:
             database_= self.name,
         )
         return "Copied " + type + "(" + id_value + ") to " + node_type_new + "(" + id_value_new + ")"
+    
+
+    def add_global_settings_node(self):
+        """Create global settings node"""        
+        return self.__add_node(self.global_settings_type, self.global_settings_id, self.global_settings_id_value)
 
 
+    def modify_global_settings_property(self, property_name, new_data):
+        """Modify global settings node""" 
+        return self.__modify_node_data(self.global_settings_type, self.global_settings_id, self.global_settings_id_value, property_name, new_data)
+    
+        
+    def delete_global_settings_property(self, property_name):
+        """Removes specific Settings property data (and property)""" 
+        return self.__delete_property(self.global_settings_type, self.global_settings_id, self.global_settings_id_value, property_name)
+
+
+    def lookup_global_settings_property(self, property_name):
+        """Return data of specific property from settings""" 
+        return self.__lookup_node_property(self.global_settings_type, self.global_settings_id, self.global_settings_id_value, property_name)
+    
+
+    def delete_global_settings(self):
+        return self.__delete_node(self.global_settings_type, self.global_settings_id, self.global_settings_id_value)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -32,7 +32,7 @@ import os
 driver = GraphDatabase.driver(os.getenv('NEO4J_URL'), auth=(os.getenv('NEO4J_USER'), os.getenv('NEO4J_PASSWORD')))
 
 # name of the global settings node
-settings_node_name = 'Base'
+settings_node_name = 'Global'
 
 # database name (default = 'neo4j')
 database_name = 'neo4j'

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -456,29 +456,33 @@ class database:
         """Create Result node with all the connected information."""
         return_a = self.__add_node(self.result_type, self.result_id, result_id_value)
         return_b = self.__connect_result_to_project(result_id_value, project_id_value)
-        # search connected Dataset, make a copy of that and connect it
+        ### search connected Dataset, make a copy of that and connect it
         project_dataset_id_value = self.__lookup_connected_node_property(self.project_type, self.project_id, project_id_value, self.connect_dataset_project, self.dataset_id)
         return_e = self.__copy_node(self.dataset_type, self.dataset_id, project_dataset_id_value, self.used_dataset_type, self.used_dataset_id, used_dataset_id_value)
         return_f = self.__connect_used_dataset_to_result(used_dataset_id_value, result_id_value)
 
-        # make a copy of AnalyzeModel and connect it
-        return_c = self.__copy_node(self.analyze_model_type, analyze_model_id_value, self.used_analyze_model_type, self.used_analyze_model_id, used_analyze_model_id_value)
+        ### make a copy of AnalyzeModel and connect it
+        return_c = self.__copy_node(self.analyze_model_type, self.analyze_model_id, analyze_model_id_value, self.used_analyze_model_type, self.used_analyze_model_id, used_analyze_model_id_value)
         return_d = self.__connect_used_analyze_model_to_result(used_analyze_model_id_value, result_id_value)
-        # search connected Dataset, make a copy of that and connect it
+        ### search connected Dataset, make a copy of that and connect it
         analyze_model_dataset_id_value = self.__lookup_connected_node_property(self.analyze_model_type, self.analyze_model_id, analyze_model_id_value, self.connect_dataset_analyze_model, self.dataset_id)
-        return_e = self.__copy_node(self.dataset_type, self.dataset_id, analyze_model_dataset_id_value, self.used_dataset_type, self.used_dataset_id, used_dataset_id_value)
-        return_f = self.__connect_used_dataset_to_used_analyze_model(used_dataset_id_value, used_analyze_model_id_value)
+        return_e = self.__copy_node(self.dataset_type, self.dataset_id, analyze_model_dataset_id_value, self.used_dataset_type, self.used_dataset_id, 3)
+        return_f = self.__connect_used_dataset_to_used_analyze_model(3, used_analyze_model_id_value)
 
-        # search connected DataModel, make a copy of that and connect it
+        ### search connected DataModel, make a copy of that and connect it
         project_data_model_id_value = self.__lookup_connected_node_property(self.project_type, self.project_id, project_id_value, self.connect_data_model_project, self.data_model_id)
         return_e = self.__copy_node(self.data_model_type, self.data_model_id, project_data_model_id_value, self.used_data_model_type, self.used_data_model_id, used_data_model_id_value)
         return_f = self.__connect_used_data_model_to_result(used_data_model_id_value, result_id_value)
-        # search connected Dataset, make a copy of that and connect it
+        ### search connected Dataset, make a copy of that and connect it
         data_model_dataset_id_value = self.__lookup_connected_node_property(self.data_model_type, self.data_model_id, project_data_model_id_value, self.connect_dataset_data_model, self.dataset_id)
-        return_g = self.__copy_node(self.dataset_type, self.dataset_id, data_model_dataset_id_value, self.used_dataset_type, self.used_dataset_id, used_dataset_id_value)
-        return_h = self.__connect_used_dataset_to_used_data_model(used_dataset_id_value, used_data_model_id_value)
+        return_g = self.__copy_node(self.dataset_type, self.dataset_id, data_model_dataset_id_value, self.used_dataset_type, self.used_dataset_id, 2)
+        return_h = self.__connect_used_dataset_to_used_data_model(2, used_data_model_id_value)
 
         return "result node created"
+
+    def set_result_property(self, id_value, property_name, new_data):
+        """Set Result property. Creates/overwrites current data.""" 
+        return self.__set_node_property(self.result_type, self.result_id, id_value, property_name, new_data)
     
     def delete_result(self, id_value):
         """Delete Result node""" 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,6 +1,49 @@
 from neo4j import GraphDatabase
 from dotenv import load_dotenv
+from enum import Enum
 import os
+
+class NodeProperties():
+    """All allowed property names for each node type.
+    """
+    class Settings(Enum):
+        # Settings
+        # example <FOO> = "foo"
+        pass
+
+    class UserSettings(Enum):
+        # User settings
+        # example <FOO> = "foo"
+        NAME = "name"
+
+    class Dataset(Enum):
+        # Dataset
+        # example <FOO> = "foo"
+        FILE_NAME = "file_name"
+
+    class DataModel(Enum):
+        # Data model
+        # example <FOO> = "foo"
+        NAME = "name"
+        NODE_TYPES = "node_types"
+        RELATIONSHIP_TYPES = "relationship_types"
+    
+    class AnalyzeModel(Enum):
+        # Analyze model
+        # example <FOO> = "foo"
+        NAME = "name"
+        KEYWORDS = "keywords"
+
+    class Project(Enum):
+        # Project
+        # example <FOO> = "foo"
+        NAME = "name"
+
+    class Result(Enum):
+        # Result
+        # example <FOO> = "foo"
+        pass
+
 
 class Database:
     def __init__(self) -> None:

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -79,7 +79,7 @@ class db_test:
         self.__failed += failed
 
         print( '--------------------')
-        print( 'Project testing:' )
+        print( 'Global testing:' )
         print( 'Success: ' + str(success) )
         print( 'Failed: ' + str(failed) )
         print( '--------------------')
@@ -238,12 +238,12 @@ class db_test:
         else:
             success += 1
 
-        print( '<Delete node>' )
-        if db.delete_project(id_value):
-            success += 1
-        else:
-            print( 'Failed' )
-            failed += 1
+        # print( '<Delete node>' )
+        # if db.delete_project(id_value):
+        #     success += 1
+        # else:
+        #     print( 'Failed' )
+        #     failed += 1
 
 
         self.__success += success
@@ -607,24 +607,6 @@ class db_test:
         print( 'Failed: ' + str(failed) )
         print( '--------------------')
 
-    def test_print_node_types(self):
-
-        print( 'Node id types:' )
-        print( 'Global settings:' )
-        print( db.get_global_settings_id_type())
-        print( 'User settings:' )
-        print( db.get_user_settings_id_type())
-        print( 'Project:' )
-        print( db.get_project_id_type())
-        print( 'Dataset:' )
-        print( db.get_dataset_id_type())
-        print( 'Data model:' )
-        print( db.get_data_model_id_type())
-        print( 'Analyze model:' )
-        print( db.get_analyze_model_id_type())
-        print( 'Result:' )
-        print( db.get_result_id_type())
-
     def test_relatioships(self):
         success = 0
         failed = 0
@@ -660,12 +642,6 @@ class db_test:
             failed += 1
 
         print( '<Data model to...>' )
-        print( '<... project>' )
-        if db.connect_data_model_to_project(data_model_id_value,project_id_value):
-            success += 1
-        else:
-            print( 'Failed' )
-            failed += 1
 
 
         print( '<Error testing>' )
@@ -742,8 +718,6 @@ class db_test:
     def test_bulk(self):
         ### debug cleaning
         print( db.debug_clear_all() )
-
-        self.test_print_node_types()
 
         self.test_global_settings()
         self.test_user_settings()

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -430,6 +430,94 @@ class db_test:
         print( 'Failed: ' + str(failed) )
         print( '--------------------')
 
+    def test_blueprint(self):
+        success = 0
+        failed = 0
+
+        print( '### Blueprint testing' )
+        
+        print( '<Creation>' )
+        id_value = db.add_blueprint_node()
+        if id_value == None:
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Set property>' )
+        if db.set_blueprint_property(id_value, NodeProperties.Blueprint.TEST_PASS, 'puhe_malli'):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Lookup property>' )
+        if db.lookup_blueprint_property(id_value, NodeProperties.Blueprint.TEST_PASS) == 'puhe_malli':
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Lookup property from non existent node>' )
+        if db.lookup_blueprint_property('wrong_node_id_value', NodeProperties.Blueprint.TEST_PASS) == None:
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Lookup non existent property>' )
+        if db.lookup_blueprint_property(id_value, NodeProperties.Blueprint.TEST_FAIL) == None:
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Remove property>' )
+        if db.remove_blueprint_property(id_value, NodeProperties.Blueprint.TEST_PASS):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Remove property from non existent node>' )
+        if db.remove_blueprint_property('wrong_node_id_value', NodeProperties.Blueprint.TEST_PASS):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Remove non existent property>' )
+        if db.remove_blueprint_property(id_value, NodeProperties.Blueprint.TEST_FAIL):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Delete node>' )
+        if db.delete_blueprint(id_value):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Delete non existent node>' )
+        if db.delete_blueprint('wrong_node_id_value'):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+
+        self.__success += success
+        self.__failed += failed
+
+
+        print( '--------------------')
+        print( 'Blueprint testing:' )
+        print( 'Success: ' + str(success) )
+        print( 'Failed: ' + str(failed) )
+        print( '--------------------')
+
 
     def test_analyze_model(self):
         success = 0
@@ -661,6 +749,7 @@ class db_test:
         self.test_user_settings()
         self.test_dataset()
         self.test_data_model()
+        self.test_blueprint()
         self.test_analyze_model()
         self.test_project()
 

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -1,0 +1,674 @@
+
+
+#from ..app.database import database
+#import sys
+#sys.path.append('../app')
+from app.database import Database, NodeProperties
+
+# Supress neo4j warnings on error tests
+import logging
+logging.getLogger("neo4j").setLevel(logging.ERROR)
+
+db = Database()
+
+class db_test:
+    def __init__(self) -> None:
+        self.__success = 0
+        self.__failed = 0
+
+    def test_global_settings(self):
+        success = 0
+        failed = 0
+
+        print( '### Global settings testing' )
+        
+        print( '<Creation>' )
+        id_value = db.add_global_settings_node()
+        if id_value == None:
+            print( 'Failed' )
+            failed += 1
+        elif id_value == 'Global':
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Set property>' )
+        if db.set_global_settings_property(NodeProperties.GlobalSettings.TEST_PASS, 'Verdana'):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Lookup property>' )
+        if db.lookup_global_settings_property(NodeProperties.GlobalSettings.TEST_PASS) == 'Verdana':
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Lookup non existent property>' )
+        if db.lookup_global_settings_property(NodeProperties.GlobalSettings.TEST_FAILED) == None:
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Remove property>' )
+        if db.remove_global_settings_property(NodeProperties.GlobalSettings.TEST_PASS):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Remove non existent property>' )
+        if db.remove_global_settings_property(NodeProperties.GlobalSettings.TEST_FAILED):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Delete node>' )
+        if db.delete_global_settings():
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        self.__success += success
+        self.__failed += failed
+
+        print( '--------------------')
+        print( 'Project testing:' )
+        print( 'Success: ' + str(success) )
+        print( 'Failed: ' + str(failed) )
+        print( '--------------------')
+
+
+    def test_user_settings(self):
+        success = 0
+        failed = 0
+
+        print( '### User settings testing' )
+        
+        print( '<Creation>' )
+        id_value = db.add_user_settings_node('jaak')
+        if id_value == None:
+            print( 'Failed' )
+            failed += 1
+        elif id_value == 'jaak':
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Set property>' )
+        if db.set_user_settings_property(id_value, NodeProperties.UserSettings.TEST_PASS, 'Jaakko'):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Lookup property>' )
+        if db.lookup_user_settings_property(id_value, NodeProperties.UserSettings.TEST_PASS) == 'Jaakko':
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Lookup property from non existent node>' )
+        if db.lookup_user_settings_property('wrong_node_id_value', NodeProperties.UserSettings.TEST_PASS) == None:
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Lookup non existent property>' )
+        if db.lookup_user_settings_property(id_value, NodeProperties.UserSettings.TEST_FAILED) == None:
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Remove property>' )
+        if db.remove_user_settings_property(id_value, NodeProperties.UserSettings.TEST_PASS):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Remove property from non existent node>' )
+        if db.remove_user_settings_property('wrong_node_id_value', NodeProperties.UserSettings.TEST_PASS):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Remove non existent property>' )
+        if db.remove_user_settings_property(id_value, NodeProperties.UserSettings.TEST_FAILED):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Delete node>' )
+        if db.delete_user_settings(id_value):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Delete non existent node>' )
+        if db.delete_user_settings('wrong_node_id_value'):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        self.__success += success
+        self.__failed += failed
+        
+        print( '--------------------')
+        print( 'User settings testing:' )
+        print( 'Success: ' + str(success) )
+        print( 'Failed: ' + str(failed) )
+        print( '--------------------')
+
+
+    def test_project(self):
+        success = 0
+        failed = 0
+
+        print( '### Project testing' )
+        
+        print( '<Creation>' )
+        id_value = db.add_project_node()
+        if id_value == None:
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Set property>' )
+        if db.set_project_property(id_value, NodeProperties.Project.TEST_PASS, 'Eduskunta'):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Lookup property>' )
+        if db.lookup_project_property(id_value, NodeProperties.Project.TEST_PASS) == 'Eduskunta':
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Lookup property from non existent node>' )
+        if db.lookup_project_property('wrong_node_id_value', NodeProperties.Project.TEST_PASS) == None:
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Lookup non existent property>' )
+        if db.lookup_project_property(id_value, NodeProperties.Project.TEST_FAILED) == None:
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Remove property>' )
+        if db.remove_project_property(id_value, NodeProperties.Project.TEST_PASS):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Remove property from non existent node>' )
+        if db.remove_project_property('wrong_node_id_value', NodeProperties.Project.TEST_PASS):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Remove non existent property>' )
+        if db.remove_project_property(id_value, NodeProperties.Project.TEST_FAILED):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Delete node>' )
+        if db.delete_project(id_value):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+
+        self.__success += success
+        self.__failed += failed
+        
+
+        print( '--------------------')
+        print( 'Project testing:' )
+        print( 'Success: ' + str(success) )
+        print( 'Failed: ' + str(failed) )
+        print( '--------------------')
+
+
+    def test_dataset(self):
+        success = 0
+        failed = 0
+
+
+        print( '### Dataset testing' )
+        print( '<Creation>' )
+        id_value = db.add_dataset_node()
+        if id_value == None:
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Set property>' )
+        if db.set_dataset_property(id_value, 'puheet_2024.pdf'):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Lookup property>' )
+        if db.lookup_dataset_property(id_value) == 'puheet_2024.pdf':
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Lookup non existent node property>' )
+        if db.lookup_dataset_property('wrong_node_id_value') == None:
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Remove property>' )
+        if db.remove_dataset_property(id_value):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Remove property from non existent node>' )
+        if db.remove_dataset_property('wrong_id_value'):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Remove non existent property>' )
+        id_value_2 = db.add_dataset_node()
+        if db.remove_dataset_property(id_value_2):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Delete node>' )
+        if db.delete_dataset(id_value):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Delete non existent node>' )
+        if db.delete_dataset('wrong_node_id_value'):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        # cleanup
+        db.delete_dataset(id_value_2)
+
+
+        self.__success += success
+        self.__failed += failed
+
+
+        print( '--------------------')
+        print( 'Dataset testing:' )
+        print( 'Success: ' + str(success) )
+        print( 'Failed: ' + str(failed) )
+        print( '--------------------')
+
+    def test_data_model(self):
+        success = 0
+        failed = 0
+
+        print( '### Data model testing' )
+        
+        print( '<Creation>' )
+        id_value = db.add_data_model_node()
+        if id_value == None:
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Set property>' )
+        if db.set_data_model_property(id_value, NodeProperties.DataModel.TEST_PASS, 'puhe_malli'):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Lookup property>' )
+        if db.lookup_data_model_property(id_value, NodeProperties.DataModel.TEST_PASS) == 'puhe_malli':
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Lookup property from non existent node>' )
+        if db.lookup_data_model_property('wrong_node_id_value', NodeProperties.DataModel.TEST_PASS) == None:
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Lookup non existent property>' )
+        if db.lookup_data_model_property(id_value, NodeProperties.DataModel.TEST_FAILED) == None:
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Remove property>' )
+        if db.remove_data_model_property(id_value, NodeProperties.DataModel.TEST_PASS):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Remove property from non existent node>' )
+        if db.remove_data_model_property('wrong_node_id_value', NodeProperties.DataModel.TEST_PASS):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Remove non existent property>' )
+        if db.remove_data_model_property(id_value, NodeProperties.DataModel.TEST_FAILED):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Delete node>' )
+        if db.delete_data_model(id_value):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Delete non existent node>' )
+        if db.delete_data_model('wrong_node_id_value'):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+
+        self.__success += success
+        self.__failed += failed
+
+
+        print( '--------------------')
+        print( 'Data model testing:' )
+        print( 'Success: ' + str(success) )
+        print( 'Failed: ' + str(failed) )
+        print( '--------------------')
+
+
+    def test_analyze_model(self):
+        success = 0
+        failed = 0
+
+        print( '### Analyze model testing' )
+        
+        print( '<Creation>' )
+        id_value = db.add_analyze_model_node()
+        if id_value == None:
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Set property>' )
+        if db.set_analyze_model_property(id_value, NodeProperties.AnalyzeModel.TEST_PASS, 'puhe_malli'):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Lookup property>' )
+        if db.lookup_analyze_model_property(id_value, NodeProperties.AnalyzeModel.TEST_PASS) == 'puhe_malli':
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Lookup property from non existent node>' )
+        if db.lookup_analyze_model_property('wrong_node_id_value', NodeProperties.AnalyzeModel.TEST_PASS) == None:
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Lookup non existent property>' )
+        if db.lookup_analyze_model_property(id_value, NodeProperties.AnalyzeModel.TEST_FAILED) == None:
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Remove property>' )
+        if db.remove_analyze_model_property(id_value, NodeProperties.AnalyzeModel.TEST_PASS):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Remove property from non existent node>' )
+        if db.remove_analyze_model_property('wrong_node_id_value', NodeProperties.AnalyzeModel.TEST_PASS):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Remove non existent property>' )
+        if db.remove_analyze_model_property(id_value, NodeProperties.AnalyzeModel.TEST_FAILED):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Delete node>' )
+        if db.delete_analyze_model(id_value):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<Delete node>' )
+        if db.delete_analyze_model('wrong_node_id_value'):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+
+        self.__success += success
+        self.__failed += failed
+
+
+        print( '--------------------')
+        print( 'Analyze model testing:' )
+        print( 'Success: ' + str(success) )
+        print( 'Failed: ' + str(failed) )
+        print( '--------------------')
+
+    def test_print_node_types(self):
+
+        print( 'Node id types:' )
+        print( 'Global settings:' )
+        print( db.get_global_settings_id_type())
+        print( 'User settings:' )
+        print( db.get_user_settings_id_type())
+        print( 'Project:' )
+        print( db.get_project_id_type())
+        print( 'Dataset:' )
+        print( db.get_dataset_id_type())
+        print( 'Data model:' )
+        print( db.get_data_model_id_type())
+        print( 'Analyze model:' )
+        print( db.get_analyze_model_id_type())
+        print( 'Result:' )
+        print( db.get_result_id_type())
+
+    def test_relatioships(self):
+        success = 0
+        failed = 0
+
+        print( '### Relationship testing' )
+        print( '<Creations>' )
+
+        print( '<Dataset to...>' )
+        dataset_id_value = db.add_dataset_node()
+
+        print( '<... data model>' )
+        data_model_id_value = db.add_data_model_node()
+        if db.connect_dataset_to_data_model(dataset_id_value,data_model_id_value):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<... analyze model>' )
+        analyze_model_id_value = db.add_analyze_model_node()
+        if db.connect_dataset_to_analyze_model(dataset_id_value,analyze_model_id_value):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+        
+        print( '<... project>' )
+        project_id_value = db.add_project_node()
+        if db.connect_dataset_to_project(dataset_id_value,project_id_value):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+        print( '<Data model to...>' )
+        print( '<... project>' )
+        if db.connect_data_model_to_project(data_model_id_value,project_id_value):
+            success += 1
+        else:
+            print( 'Failed' )
+            failed += 1
+
+
+        print( '<Error testing>' )
+        print( '<Bad dataset...>' )
+        print( '<... data model>' )
+        if db.connect_dataset_to_data_model('bad',data_model_id_value):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+        
+        print( '<... analyze model>' )
+        if db.connect_dataset_to_analyze_model('bad',analyze_model_id_value):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+        
+        print( '<... project>' )
+        if db.connect_dataset_to_project('bad',project_id_value):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+        
+        print( '<Dataset...>' )
+        print( '<... bad data model>' )
+        if db.connect_dataset_to_data_model(dataset_id_value,'bad'):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+        
+        print( '<... bad analyze model>' )
+        if db.connect_dataset_to_analyze_model(dataset_id_value,'bad'):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+        
+        print( '<... bad project>' )
+        if db.connect_dataset_to_project(dataset_id_value,'bad'):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+        print( '<Bad to bad>' )
+        if db.connect_dataset_to_project('bad','bad'):
+            print( 'Failed' )
+            failed += 1
+        else:
+            success += 1
+
+
+        # cleanup
+        db.delete_dataset(dataset_id_value)
+        db.delete_data_model(data_model_id_value)
+        db.delete_analyze_model(analyze_model_id_value)
+        db.delete_project(project_id_value)
+
+
+        self.__success += success
+        self.__failed += failed
+
+
+        print( '--------------------')
+        print( 'Relationship testing:' )
+        print( 'Success: ' + str(success) )
+        print( 'Failed: ' + str(failed) )
+        print( '--------------------')   
+
+
+    def test_bulk(self):
+        ### debug cleaning
+        print( db.debug_clear_all() )
+
+        self.test_print_node_types()
+
+        self.test_global_settings()
+        self.test_user_settings()
+        self.test_dataset()
+        self.test_data_model()
+        self.test_analyze_model()
+        self.test_project()
+
+        self.test_relatioships()
+
+        print( '--------------------')
+        print( 'Bulk testing:' )
+        print( 'Success: ' + str(self.__success) )
+        print( 'Failed: ' + str(self.__failed) )
+        print( '--------------------')   
+

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -48,7 +48,7 @@ class db_test:
             failed += 1
         
         print( '<Lookup non existent property>' )
-        if db.lookup_global_settings_property(NodeProperties.GlobalSettings.TEST_FAILED) == None:
+        if db.lookup_global_settings_property(NodeProperties.GlobalSettings.TEST_FAIL) == None:
             success += 1
         else:
             print( 'Failed' )
@@ -62,7 +62,7 @@ class db_test:
             failed += 1
 
         print( '<Remove non existent property>' )
-        if db.remove_global_settings_property(NodeProperties.GlobalSettings.TEST_FAILED):
+        if db.remove_global_settings_property(NodeProperties.GlobalSettings.TEST_FAIL):
             print( 'Failed' )
             failed += 1
         else:
@@ -124,7 +124,7 @@ class db_test:
             failed += 1
         
         print( '<Lookup non existent property>' )
-        if db.lookup_user_settings_property(id_value, NodeProperties.UserSettings.TEST_FAILED) == None:
+        if db.lookup_user_settings_property(id_value, NodeProperties.UserSettings.TEST_FAIL) == None:
             success += 1
         else:
             print( 'Failed' )
@@ -145,7 +145,7 @@ class db_test:
             success += 1
 
         print( '<Remove non existent property>' )
-        if db.remove_user_settings_property(id_value, NodeProperties.UserSettings.TEST_FAILED):
+        if db.remove_user_settings_property(id_value, NodeProperties.UserSettings.TEST_FAIL):
             print( 'Failed' )
             failed += 1
         else:
@@ -211,7 +211,7 @@ class db_test:
             failed += 1
         
         print( '<Lookup non existent property>' )
-        if db.lookup_project_property(id_value, NodeProperties.Project.TEST_FAILED) == None:
+        if db.lookup_project_property(id_value, NodeProperties.Project.TEST_FAIL) == None:
             success += 1
         else:
             print( 'Failed' )
@@ -232,7 +232,7 @@ class db_test:
             success += 1
 
         print( '<Remove non existent property>' )
-        if db.remove_project_property(id_value, NodeProperties.Project.TEST_FAILED):
+        if db.remove_project_property(id_value, NodeProperties.Project.TEST_FAIL):
             print( 'Failed' )
             failed += 1
         else:
@@ -378,7 +378,7 @@ class db_test:
             failed += 1
         
         print( '<Lookup non existent property>' )
-        if db.lookup_data_model_property(id_value, NodeProperties.DataModel.TEST_FAILED) == None:
+        if db.lookup_data_model_property(id_value, NodeProperties.DataModel.TEST_FAIL) == None:
             success += 1
         else:
             print( 'Failed' )
@@ -399,7 +399,7 @@ class db_test:
             success += 1
 
         print( '<Remove non existent property>' )
-        if db.remove_data_model_property(id_value, NodeProperties.DataModel.TEST_FAILED):
+        if db.remove_data_model_property(id_value, NodeProperties.DataModel.TEST_FAIL):
             print( 'Failed' )
             failed += 1
         else:
@@ -467,7 +467,7 @@ class db_test:
             failed += 1
         
         print( '<Lookup non existent property>' )
-        if db.lookup_analyze_model_property(id_value, NodeProperties.AnalyzeModel.TEST_FAILED) == None:
+        if db.lookup_analyze_model_property(id_value, NodeProperties.AnalyzeModel.TEST_FAIL) == None:
             success += 1
         else:
             print( 'Failed' )
@@ -488,7 +488,7 @@ class db_test:
             success += 1
 
         print( '<Remove non existent property>' )
-        if db.remove_analyze_model_property(id_value, NodeProperties.AnalyzeModel.TEST_FAILED):
+        if db.remove_analyze_model_property(id_value, NodeProperties.AnalyzeModel.TEST_FAIL):
             print( 'Failed' )
             failed += 1
         else:

--- a/backend/tests/tests.py
+++ b/backend/tests/tests.py
@@ -1,0 +1,8 @@
+# runs from backend directory with "python -m tests.tests"
+from tests.test_database import *
+
+test_db = db_test()
+
+if __name__ == "__main__":
+
+    test_db.test_bulk()


### PR DESCRIPTION
closes #32 #48 #51 #52 #61 #62 #58 

Follows Database design v4.

Import:
`from app.database import Database`
Initialize:
`db = Database()`

Provides initial access to database (public):
- `.debug_clear_all()` to wipe database
- `.debug_show_all()` to print database in console
- node creation `(.add_<node_type>_node )`
- add/modify **single** property data `(.set_<node_type>_property )`
- create relationship between nodes (according to above design)` (.connect_a_->_b )`
- remove single property `(.remove_<node_type>_property )`
- get **single** property data from database `(.lookup_<node_type>_property )`
- get list of nodes `(.lookup_<node_type>_nodes)`
- get list of nodes parent to specific node (like list of datasets for a datamodel) `(.lookup_<node_type>_nodes_<parent_type>)`
- delete node(s) `(.delete_<node_type>)`. Can have different functionality depending on node type. Deleting Project deletes more than just Project (results). Deleting dataset only deletes dataset. Deleting model also deletes it's possible dataset.

Returns:
- True when query succeeded
- False when something went wrong
- "data" when getting property data
- None when something went wrong (data retrieval)
- id_value of node when creating a node
- [id, property_name] list when getting list of nodes of certain node_type

example:
```
.add_global_settings_node()
.set_global_settings_property(property_name, new_data)
.remove_global_settings_property(property_name)
.lookup_global_settings_property(property_name)
.delete_global_settings()
```

Notes:
- When saving datetime to database it needs to be in ISO-format `.isoformat()`

Deeper example: https://github.com/ProjectCED/CED-LLM/issues/58#issuecomment-2414788302