### PR TITLE
71 Database: Listing of nodes missing from main

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -298,8 +298,7 @@ class Database:
         try:
             # gives out [[ ]]
             double_list = next(iter(records)).data()['list']
-            single_list = [item for sublist in double_list for item in sublist]
-            return single_list
+            return double_list
         except:
             return None
         
@@ -733,7 +732,13 @@ class Database:
     def lookup_dataset_property(self, id_value):
         """Return data of specific property from Dataset""" 
         return self.__lookup_node_property(self.__dataset_type, self.__dataset_id, id_value, self.__dataset_property)
-    
+
+
+    def lookup_dataset_nodes_data_model(self, parent_id_value):
+        """Return list of Dataset"""
+        parent_info = {'node_type': self.__data_model_type, 'id_type': self.__data_model_id, 'id_value': parent_id_value}
+        return self.__lookup_nodes(self.__dataset_type, self.__dataset_id, self.__dataset_property, parent_info)
+
 
     def remove_dataset_property(self, id_value):
         """Remove data of specific property from Dataset"""
@@ -860,6 +865,20 @@ class Database:
     def __set_used_dataset_property(self, id_value, new_data):
         """Set Used Dataset property. Creates/overwrites current data.""" 
         return self.__set_node_property(self.__used_dataset_type, self.__used_dataset_id, id_value, self.__dataset_property, new_data)
+    
+
+    def lookup_used_dataset_nodes_used_data_model(self, parent_id_value):
+        """Return list of Used Dataset"""
+        parent_info = {"node_type": self.__used_data_model_type, "id_type": self.__used_data_model_id, "id_value": parent_id_value}
+        return self.__lookup_nodes(self.__used_dataset_type, self.__dataset_id, self.__dataset_property, parent_info)
+    
+    
+    ### Used datamodel
+    def lookup_used_data_model_nodes_result_blueprint(self, parent_id_value):
+        """Return list of Used data model"""
+        parent_info = {"node_type": self.__result_blueprint_type, "id_type": self.__result_blueprint_id, "id_value": parent_id_value}
+        return self.__lookup_nodes(self.__used_data_model_type, self.__used_data_model_id, NodeProperties.DataModel.NAME.value, parent_info)
+
 
     ### Result Blueprint
 


### PR DESCRIPTION
closes #71 

This includes missed features from missing the last commit to https://github.com/ProjectCED/CED-LLM/pull/60

- Lookup not returning proper [[]] structure
- Datasets from data models missing
- Datasets from Used data models missing
- Used data models from result(blueprint) missing


Part in the example:

`

        # get list of projects [[id, name]] .. notice double "list"
        print(db.lookup_project_nodes())
        # console: [['b472496d-fe0f-4e32-a96b-ce6392c15168', 'projekti']]
        
        # get list of results to certain project [[id, datetime]] .. notice double "list"
        result_list = db.lookup_result_blueprint_nodes(project_id)
        print(result_list)
        # console: [['7d8f3294-c18b-4a70-89de-541eca511504', '2024-10-16T13:19:05.823774']]
        
        # get list of used data models of certain result [[id, name]] .. notice double "list"
        data_model_list = db.lookup_used_data_model_nodes_result_blueprint(result_list[0][0])
        print(data_model_list)
        # [['c517125c-3a53-4ceb-a565-ce06ae958347', 'd-model 2'], ['4424ef2f-3b7b-46c6-95aa-beaa5e4698cc', 'd-model 1']]
        
        # get list of dataset for each used data model[[id, file_name]] .. notice double "list"
        for data_model in data_model_list:
            dataset_list = db.lookup_used_dataset_nodes_used_data_model(data_model[0])
            print(dataset_list)
        # console model 1:  [['c7c561ec-7a10-4f8c-b970-7ba2ef5923f8', 'esim2.pdf'], ['224ebf3f-a2fb-4447-89ff-c90026d03e96', 'esim.pdf']]
        # console model 2: []


`