### PR TITLE
47 database dummy db

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import os
 
 class NodeProperties:
-    """All allowed property names for each node type.
+    """All allowed property names for each node label.
 
     Add more properties here when needed, but check Database class init for reserved names for identifier usage before adding new property names.
     """
@@ -37,7 +37,7 @@ class NodeProperties:
         # Data model
         # example FOO = "foo"
         NAME = "name"
-        NODE_TYPES = "node_types"
+        NODE_LABELS = "node_labes"
         RELATIONSHIP_TYPES = "relationship_types"
 
         TEST_PASS = "test_pass"
@@ -107,7 +107,7 @@ class Database(metaclass=DatabaseMeta):
     def __init__(self) -> None:
         """Start up database driver.
         Setup (according to database design v4):
-          - types(labels)
+          - labels
           - identifier names
           - relationship types
         """
@@ -623,7 +623,7 @@ class Database(metaclass=DatabaseMeta):
     def __copy_node(self, type, id_type, id_value, node_type_new, id_type_new, id_value_new = None):
         """return id of new node when copy succeeded, None if failed
         new id value is optional
-        Copy node into a new node type.
+        Copy node into a new node label.
 
         Args:
             type (string): Node label
@@ -757,7 +757,7 @@ class Database(metaclass=DatabaseMeta):
     
     def __does_property_exist(self, type, id_type, id_value, property_name):
         """
-        Check if node with specific node type and property value exists
+        Check if node with specific node label and property value exists
 
         Args:
             type (string): Node label
@@ -797,7 +797,7 @@ class Database(metaclass=DatabaseMeta):
         
     def __does_node_exist(self, type, id_type, id_value):
         """
-        Check if node exists with specific node type and id value
+        Check if node exists with specific node label and id value
 
         Args:
             type (string): Node label

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1888,7 +1888,7 @@ class Database(metaclass=DatabaseMeta):
 
 
     ### Used Blueprint
-    def add_used_blueprint_node(self, id_value):
+    def copy_to_used_blueprint_node(self, id_value):
         """
         Copies blueprint node into used-variant.
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1901,7 +1901,7 @@ class Database(metaclass=DatabaseMeta):
         Returns:
             string: string containing ID value for the used-variant node. 
         """
-        return self.__copy_node(self.__blueprint_type, id_value, self.__used_blueprint_type)
+        return self.__copy_node(self.__blueprint_type, self.__blueprint_id, id_value, self.__used_blueprint_type, self.__used_blueprint_id)
 
     def lookup_used_blueprint_property(self, id_value, property_name: NodeProperties.Blueprint):
         """

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1888,6 +1888,21 @@ class Database(metaclass=DatabaseMeta):
 
 
     ### Used Blueprint
+    def add_used_blueprint_node(self, id_value):
+        """
+        Copies blueprint node into used-variant.
+
+        Args:
+            id_value (string): Value for the "active" blueprint id
+
+        Raises:
+            RuntimeError: If database query error.
+
+        Returns:
+            string: string containing ID value for the used-variant node. 
+        """
+        return self.__copy_node(self.__blueprint_type, id_value, self.__used_blueprint_type)
+
     def lookup_used_blueprint_property(self, id_value, property_name: NodeProperties.Blueprint):
         """
         Return data of specific property from UsedBlueprint

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -2010,15 +2010,14 @@ class Database(metaclass=DatabaseMeta):
     #         return None
     
     '''
-    def add_result_blueprint_node(self, project_id, dataset_list, blueprint_ids, datamodel_ids):
+    def add_result_blueprint_node(self, project_id, blueprint_ids = None, dataset_list = None):
         """
         Create Result-blueprint node.
         
         Args:
             project_id (string): Parent project node id
-            dataset_list (list of string): dataset file names
-            blueprint_ids (list of strings): list of blueprint ids
-            datamodel_ids (list of strings): list of data model ids
+            blueprint_ids (list of strings, optional): list of blueprint ids
+            dataset_list (list of string, optional): dataset file names, will create Dataset-nodes
         
         Raises:
             RuntimeError: If database query error.
@@ -2042,16 +2041,6 @@ class Database(metaclass=DatabaseMeta):
         for id in blueprint_ids:
             used_blueprint_id = self.__copy_node(self.__blueprint_type, self.__blueprint_id, id, self.__used_blueprint_type, self.__used_blueprint_id)
             self.__connect_used_blueprint_to_result_blueprint(used_blueprint_id, result_blueprint_id)
-
-        # datamodels and it's datasets
-        for id in datamodel_ids:
-            used_data_model_id = self.__copy_node(self.__data_model_type, self.__data_model_id, id, self.__used_data_model_type, self.__used_data_model_id)
-            datamodel_dataset_ids = self.__lookup_node_neighbours(self.__data_model_type, self.__data_model_id, id, self.__dataset_type, self.__dataset_id, self.__connect_dataset_data_model) 
-            if datamodel_dataset_ids != None:
-                for datamodel_dataset_id in datamodel_dataset_ids:
-                    new_used_dataset_id = self.__copy_node(self.__dataset_type, self.__dataset_id, datamodel_dataset_id, self.__used_dataset_type, self.__used_dataset_id)
-                    self.__connect_used_dataset_to_used_data_model(new_used_dataset_id, used_data_model_id)
-            self.__connect_used_data_model_to_result_blueprint(used_data_model_id, result_blueprint_id)
 
         # result -> project
         self.__connect_result_blueprint_to_project(result_blueprint_id, project_id)

--- a/backend/app/database_dummy.py
+++ b/backend/app/database_dummy.py
@@ -1,5 +1,6 @@
 from app.database import Database, NodeProperties
 
+# just for show questions, don't use these
 blueprint_questions = [
     'Lorem Ipsum dolor sit amet, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat?',
     'Lorem Ipsum sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, vel iusto odio dignissim qui blandit praesent luptatum zzril?',
@@ -8,15 +9,15 @@ blueprint_questions = [
     'Lorem Ipsum Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur?',
 ]
 
-classification_node_labels = [
+# Just for show data model, don't use these
+data_model_node_labels = [
     'AuraTangle',
     'LinkageMist',
     'GlyphShade',
     'BloomEmber',
     'PathwayTwist',
 ]
-
-classification_node_relationships = [
+data_model_node_relationships = [
     'ECHOES_WITH',
     'FLOWS_TOWARD',
     'LOOPS_INTO',
@@ -206,23 +207,23 @@ class DatabaseDummy:
                 ),
             (
                 'Wayfinder Realm',
-                classification_node_labels,
-                classification_node_relationships,
+                data_model_node_labels,
+                data_model_node_relationships,
                 ),
             (
                 'SoftTag Grove',
-                classification_node_labels,
-                classification_node_relationships,
+                data_model_node_labels,
+                data_model_node_relationships,
                 ),
             (
                 'Ramble Field',
-                classification_node_labels,
-                classification_node_relationships,
+                data_model_node_labels,
+                data_model_node_relationships,
                 ),
             (
                 'Freespace Catalog',
-                classification_node_labels,
-                classification_node_relationships,
+                data_model_node_labels,
+                data_model_node_relationships,
                 ),
         ]
         self.__datamodels(__datamodels)
@@ -244,6 +245,7 @@ class DatabaseDummy:
         for user in users:
             # Create nodes with email
             id = self.db.add_user_settings_node(user[1])
+
             if not user[0] == None:
                 self.db.set_user_settings_property(id, NodeProperties.UserSettings.NAME, user[0])
             # add more here
@@ -252,10 +254,13 @@ class DatabaseDummy:
         '''Blueprints'''
         for blueprint in blueprints:
             id = self.db.add_blueprint_node()
+
             if not blueprint[0] == None:
                 self.db.set_blueprint_property(id, NodeProperties.Blueprint.NAME, blueprint[0])
+
             if not blueprint[1] == None:
                 self.db.set_blueprint_property(id, NodeProperties.Blueprint.DESCRIPTION, blueprint[1])
+
             if not blueprint[2] == None:
                 self.db.set_blueprint_property(id, NodeProperties.Blueprint.QUESTIONS, blueprint[2])
             # add more here
@@ -266,8 +271,10 @@ class DatabaseDummy:
             id = self.db.add_data_model_node()
             if not datamodel[0] == None:
                 self.db.set_data_model_property(id, NodeProperties.DataModel.NAME, datamodel[0])
+
             if not datamodel[1] == None:
                 self.db.set_data_model_property(id, NodeProperties.DataModel.NODE_LABELS, datamodel[1])
+
             if not datamodel[2] == None:
                 self.db.set_data_model_property(id, NodeProperties.DataModel.RELATIONSHIP_TYPES, datamodel[2])
             # add more here
@@ -276,6 +283,7 @@ class DatabaseDummy:
         '''Projects'''
         for project in projects:
             id = self.db.add_project_node()
+
             if not project[0] == None:
                 self.db.set_project_property(id, NodeProperties.Project.NAME, project[0])
             # add more here
@@ -283,7 +291,7 @@ class DatabaseDummy:
 
     def __result_blueprint(self, results):
         '''Result-Blueprint'''
-        nodes = self.db.lookup_project_nodes()
+        projects = self.db.lookup_project_nodes()
         blueprints = self.db.lookup_blueprint_nodes()
         for result in results:
             result_id = self.db.add_result_blueprint_node()
@@ -295,18 +303,21 @@ class DatabaseDummy:
                     blueprint_id = blue_id
 
             # connect results to specific projects
-            for project_id, project_name in nodes:
+            for project_id, project_name in projects:
                 if project_name == result[0]:
                     # result -> project
                     self.db.connect_result_blueprint_to_project(result_id, project_id)
                     # used blueprint -> result
                     used_blue_id = self.db.copy_to_used_blueprint_node(blueprint_id)
                     self.db.connect_used_blueprint_to_result_blueprint(used_blue_id, result_id)
+
                     # properties
                     if not result[2] == None:
                         self.db.set_result_blueprint_property(result_id, NodeProperties.ResultBlueprint.DATETIME, result[2])
+
                     if not result[3] == None:
                         self.db.set_result_blueprint_property(result_id, NodeProperties.ResultBlueprint.RESULT, result[3])
+
                     if not result[4] == None:
                         self.db.set_result_blueprint_property(result_id, NodeProperties.ResultBlueprint.FILENAME, result[4])
                     # add more here

--- a/backend/app/database_dummy.py
+++ b/backend/app/database_dummy.py
@@ -194,6 +194,10 @@ class DatabaseDummy:
         ]
         self.__result_blueprint(__result_blueprints)
 
+        ### Data models
+        # [(name,
+        #   node_labels,
+        #   node_relationships)]
         __datamodels = [
             (
                 'Eduskunta',

--- a/backend/app/database_dummy.py
+++ b/backend/app/database_dummy.py
@@ -1,4 +1,4 @@
-from database import Database, NodeProperties
+from app.database import Database, NodeProperties
 
 class DatabaseDummy:
     '''Create pre-filled dummy database'''
@@ -93,7 +93,7 @@ class DatabaseDummy:
         # references __project names
         # references __blueprint names
         # [(project-name, blueprint-name, datetime.iso(), result, filename)]
-        __result_blueprint = [
+        __result_blueprints = [
             (
                 __projects[1][0],
                 __blueprints[1][0],
@@ -144,7 +144,7 @@ class DatabaseDummy:
                 'compliance_assessment_report_2024.txt',
                 ),
         ]
-        __result_blueprint(__result_blueprint)
+        self.__result_blueprint(__result_blueprints)
 
 
 

--- a/backend/app/database_dummy.py
+++ b/backend/app/database_dummy.py
@@ -185,19 +185,31 @@ class DatabaseDummy:
     def __result_blueprint(self, results):
         '''Result-Blueprint'''
         nodes = self.db.lookup_project_nodes()
+        blueprints = self.db.lookup_blueprint_nodes()
         for result in results:
-            id = self.db.add_result_blueprint_node()
+            result_id = self.db.add_result_blueprint_node()
+
+            # search blueprint id
+            blueprint_id = None
+            for blue_id, blue_name in blueprints:
+                if blue_name == result[1]:
+                    blueprint_id = blue_id
+
             # connect results to specific projects
             for project_id, project_name in nodes:
                 if project_name == result[0]:
-                    self.db.connect_result_blueprint_to_project(id, project_id)
+                    # result -> project
+                    self.db.connect_result_blueprint_to_project(result_id, project_id)
+                    # used blueprint -> result
+                    used_blue_id = self.db.add_used_blueprint_node(blueprint_id)
+                    self.db.connect_used_blueprint_to_result_blueprint(used_blue_id, result_id)
                     # properties
                     if not result[2] == None:
-                        self.db.set_result_blueprint_property(id, NodeProperties.ResultBlueprint.DATETIME, result[2])
+                        self.db.set_result_blueprint_property(result_id, NodeProperties.ResultBlueprint.DATETIME, result[2])
                     if not result[3] == None:
-                        self.db.set_result_blueprint_property(id, NodeProperties.ResultBlueprint.RESULT, result[3])
+                        self.db.set_result_blueprint_property(result_id, NodeProperties.ResultBlueprint.RESULT, result[3])
                     if not result[4] == None:
-                        self.db.set_result_blueprint_property(id, NodeProperties.ResultBlueprint.FILENAME, result[4])
+                        self.db.set_result_blueprint_property(result_id, NodeProperties.ResultBlueprint.FILENAME, result[4])
 
 
                     

--- a/backend/app/database_dummy.py
+++ b/backend/app/database_dummy.py
@@ -1,11 +1,26 @@
 from app.database import Database, NodeProperties
 
-lorem_ipsum_questions = [
+blueprint_questions = [
     'Lorem Ipsum dolor sit amet, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat?',
     'Lorem Ipsum sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, vel iusto odio dignissim qui blandit praesent luptatum zzril?',
     'Lorem Ipsum consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, enim ad minim veniam?',
     'Lorem Ipsum ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat?',
     'Lorem Ipsum Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur?',
+]
+
+classification_node_labels = [
+    'AuraTangle',
+    'LinkageMist',
+    'GlyphShade',
+    'BloomEmber',
+    'PathwayTwist',
+]
+
+classification_node_relationships = [
+    'ECHOES_WITH',
+    'FLOWS_TOWARD',
+    'LOOPS_INTO',
+    'LINKS_THROUGH',
 ]
 
 class DatabaseDummy:
@@ -66,32 +81,32 @@ class DatabaseDummy:
             (
                 'Brainstorm Blueprint',
                 'A creative framework that uses guided questions to spark innovative ideas and foster collaborative thinking.',
-                lorem_ipsum_questions,
+                blueprint_questions,
                 ),
             (
                 'Thought Explorer',
                 'A stimulating guide that encourages deep reflection and discovery through targeted questions and open-ended inquiries.',
-                lorem_ipsum_questions,
+                blueprint_questions,
                 ),
             (
                 'Inquiry Adventure',
                 'An engaging toolkit designed to inspire curiosity and exploration through a series of thought-provoking questions.',
-                lorem_ipsum_questions,
+                blueprint_questions,
                 ),
             (
                 'Dialogue Design',
                 'A structured approach that fosters meaningful conversations by providing a framework of insightful questions and prompts.',
-                lorem_ipsum_questions,
+                blueprint_questions,
                 ),
             (
                 'Idea Igniter',
                 'A creative catalyst that sparks inspiration and generates innovative ideas through targeted prompts and questions.',
-                lorem_ipsum_questions,
+                blueprint_questions,
                 ),
             (
                 'Question Quest',
                 'A playful exploration that drives discovery and insight through a series of engaging and thought-provoking questions.',
-                lorem_ipsum_questions,
+                blueprint_questions,
                 ),
         ]
         self.__blueprints(__blueprints)
@@ -178,6 +193,35 @@ class DatabaseDummy:
         ]
         self.__result_blueprint(__result_blueprints)
 
+        __datamodels = [
+            (
+                'Eduskunta',
+                None,
+                None,
+                ),
+            (
+                'Wayfinder Realm',
+                classification_node_labels,
+                classification_node_relationships,
+                ),
+            (
+                'SoftTag Grove',
+                classification_node_labels,
+                classification_node_relationships,
+                ),
+            (
+                'Ramble Field',
+                classification_node_labels,
+                classification_node_relationships,
+                ),
+            (
+                'Freespace Catalog',
+                classification_node_labels,
+                classification_node_relationships,
+                ),
+        ]
+        self.__datamodels(__datamodels)
+                
 
 
     def __clear(self):
@@ -211,6 +255,17 @@ class DatabaseDummy:
                 self.db.set_blueprint_property(id, NodeProperties.Blueprint.QUESTIONS, blueprint[2])
             # add more here
 
+    def __datamodels(self, datamodels):
+        '''Datamodels'''
+        for datamodel in datamodels:
+            id = self.db.add_data_model_node()
+            if not datamodel[0] == None:
+                self.db.set_data_model_property(id, NodeProperties.DataModel.NAME, datamodel[0])
+            if not datamodel[1] == None:
+                self.db.set_data_model_property(id, NodeProperties.DataModel.NODE_LABELS, datamodel[1])
+            if not datamodel[2] == None:
+                self.db.set_data_model_property(id, NodeProperties.DataModel.RELATIONSHIP_TYPES, datamodel[2])
+            # add more here
 
     def __projects(self, projects):
         '''Projects'''

--- a/backend/app/database_dummy.py
+++ b/backend/app/database_dummy.py
@@ -76,7 +76,7 @@ class DatabaseDummy:
             (
                 'Eduskunta ',
                 'A collaborative framework designed to enhance educational dialogue and decision-making through structured discussions and feedback.',
-                [],
+                None,
                 ),
             (
                 'Brainstorm Blueprint',

--- a/backend/app/database_dummy.py
+++ b/backend/app/database_dummy.py
@@ -1,5 +1,13 @@
 from app.database import Database, NodeProperties
 
+lorem_ipsum_questions = [
+    'Lorem Ipsum dolor sit amet, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat?',
+    'Lorem Ipsum sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, vel iusto odio dignissim qui blandit praesent luptatum zzril?',
+    'Lorem Ipsum consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, enim ad minim veniam?',
+    'Lorem Ipsum ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat?',
+    'Lorem Ipsum Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur?',
+]
+
 class DatabaseDummy:
     '''Create pre-filled dummy database'''
     def __init__(self):
@@ -45,30 +53,37 @@ class DatabaseDummy:
             (
                 'Eduskunta ',
                 'A collaborative framework designed to enhance educational dialogue and decision-making through structured discussions and feedback.',
+                [],
                 ),
             (
                 'Brainstorm Blueprint',
                 'A creative framework that uses guided questions to spark innovative ideas and foster collaborative thinking.',
+                lorem_ipsum_questions,
                 ),
             (
                 'Thought Explorer',
                 'A stimulating guide that encourages deep reflection and discovery through targeted questions and open-ended inquiries.',
+                lorem_ipsum_questions,
                 ),
             (
                 'Inquiry Adventure',
                 'An engaging toolkit designed to inspire curiosity and exploration through a series of thought-provoking questions.',
+                lorem_ipsum_questions,
                 ),
             (
                 'Dialogue Design',
                 'A structured approach that fosters meaningful conversations by providing a framework of insightful questions and prompts.',
+                lorem_ipsum_questions,
                 ),
             (
                 'Idea Igniter',
                 'A creative catalyst that sparks inspiration and generates innovative ideas through targeted prompts and questions.',
+                lorem_ipsum_questions,
                 ),
             (
                 'Question Quest',
                 'A playful exploration that drives discovery and insight through a series of engaging and thought-provoking questions.',
+                lorem_ipsum_questions,
                 ),
         ]
         self.__blueprints(__blueprints)
@@ -180,6 +195,8 @@ class DatabaseDummy:
                 self.db.set_blueprint_property(id, NodeProperties.Blueprint.NAME, blueprint[0])
             if not blueprint[1] == None:
                 self.db.set_blueprint_property(id, NodeProperties.Blueprint.DESCRIPTION, blueprint[1])
+            if not blueprint[2] == None:
+                self.db.set_blueprint_property(id, NodeProperties.Blueprint.QUESTIONS, blueprint[2])
             # add more here
 
 

--- a/backend/app/database_dummy.py
+++ b/backend/app/database_dummy.py
@@ -3,14 +3,19 @@ from app.database import Database, NodeProperties
 class DatabaseDummy:
     '''Create pre-filled dummy database'''
     def __init__(self):
-        '''When editing, be sure to have all names unique for this example to work'''
+        '''
+        When editing:
+        - be sure to have all names unique for this example to work
+        - When adding new example properties to tuples, need to add code line for it further down.
+        '''
         self.db = Database()
 
         ### clear all
         self.__clear()
 
         ### global settings
-        self.__global()
+        __global = ()
+        self.__global(__global)
 
         ### user settings
         # [(name, email)]
@@ -152,9 +157,11 @@ class DatabaseDummy:
         '''Clear database'''
         self.db.debug_clear_all()
 
-    def __global(self):
+    def __global(self, tuple):
         '''Global settings'''
         self.db.add_global_settings_node()
+        # example
+        #self.db.set_global_settings_property(NodeProperties.GlobalSettings.NEWDATA, tuple[0])
 
     def __users(self, users):
         '''User Settings'''
@@ -163,6 +170,7 @@ class DatabaseDummy:
             id = self.db.add_user_settings_node(user[1])
             if not user[0] == None:
                 self.db.set_user_settings_property(id, NodeProperties.UserSettings.NAME, user[0])
+            # add more here
 
     def __blueprints(self, blueprints):
         '''Blueprints'''
@@ -172,6 +180,7 @@ class DatabaseDummy:
                 self.db.set_blueprint_property(id, NodeProperties.Blueprint.NAME, blueprint[0])
             if not blueprint[1] == None:
                 self.db.set_blueprint_property(id, NodeProperties.Blueprint.DESCRIPTION, blueprint[1])
+            # add more here
 
 
     def __projects(self, projects):
@@ -180,6 +189,7 @@ class DatabaseDummy:
             id = self.db.add_project_node()
             if not project[0] == None:
                 self.db.set_project_property(id, NodeProperties.Project.NAME, project[0])
+            # add more here
 
 
     def __result_blueprint(self, results):
@@ -210,6 +220,7 @@ class DatabaseDummy:
                         self.db.set_result_blueprint_property(result_id, NodeProperties.ResultBlueprint.RESULT, result[3])
                     if not result[4] == None:
                         self.db.set_result_blueprint_property(result_id, NodeProperties.ResultBlueprint.FILENAME, result[4])
+                    # add more here
 
 
                     

--- a/backend/app/database_dummy.py
+++ b/backend/app/database_dummy.py
@@ -71,7 +71,8 @@ class DatabaseDummy:
 
         ### blueprints
         # [(name,
-        #   description)]
+        #   description,
+        #   questions)]
         __blueprints = [
             (
                 'Eduskunta ',

--- a/backend/app/database_dummy.py
+++ b/backend/app/database_dummy.py
@@ -3,34 +3,18 @@ from database import Database, NodeProperties
 class DatabaseDummy:
     '''Create pre-filled dummy database'''
     def __init__(self):
-        '''Initialize'''
+        '''When editing, be sure to have all names unique for this example to work'''
         self.db = Database()
 
-        # clear all
+        ### clear all
         self.__clear()
 
-        # global settings
+        ### global settings
         self.__global()
 
-        # user settings
-        self.__users()
-
-        # blueprints
-        self.__blueprints()
-
-
-    def __clear(self):
-        '''Clear database'''
-        self.db.debug_clear_all()
-
-    def __global(self):
-        '''Global settings'''
-        self.db.add_global_settings_node()
-
-    def __users(self):
-        '''User Settings'''
+        ### user settings
         # [(name, email)]
-        users = [
+        __users = [
             (
                 'John Smith',
                 'john.smith@example.com',
@@ -48,17 +32,13 @@ class DatabaseDummy:
                 'michael.brown@example.com',
                 ),
         ]
-        for user in users:
-            # Create nodes with email
-            id = self.db.add_user_settings_node(user[1])
-            self.db.set_user_settings_property(id, NodeProperties.UserSettings.NAME, user[0])
+        self.__users(__users)
 
-    def __blueprints(self):
-        '''Blueprints'''
+        ### blueprints
         # [(name, description)]
-        blueprints = [
+        __blueprints = [
             (
-                'Eduskunta',
+                'Eduskunta ',
                 'A collaborative framework designed to enhance educational dialogue and decision-making through structured discussions and feedback.',
                 ),
             (
@@ -86,10 +66,141 @@ class DatabaseDummy:
                 'A playful exploration that drives discovery and insight through a series of engaging and thought-provoking questions.',
                 ),
         ]
+        self.__blueprints(__blueprints)
 
+        ### projects
+        # [(name)]
+        __projects = [
+            (
+                'Eduskunta',
+                ),
+            (
+                'Performance Review',
+                ),
+            (
+                'Operations Enhancement',
+                ),
+            (
+                'Quality Improvement',
+                ),
+            (
+                'Compliance Assessment',
+                ),
+        ]
+        self.__projects(__projects)
+
+        ### Result-Blueprint
+        # references __project names
+        # references __blueprint names
+        # [(project-name, blueprint-name, datetime.iso(), result, filename)]
+        __result_blueprint = [
+            (
+                __projects[1][0],
+                __blueprints[1][0],
+                '2023-05-15T09:45:15',
+                'Lorem Ipsum sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+                'employee_performance_review_2024.pdf',
+                ),
+            (
+                __projects[1][0],
+                __blueprints[2][0],
+                '2022-01-01T00:00:00',
+                'Lorem Ipsum nulla facilisi, sed dapibus leo a quam ullamcorper, eu hendrerit odio condimentum.',
+                'performance_evaluation_summary_Q1_2023.txt',
+                ),
+            (
+                __projects[1][0],
+                __blueprints[3][0],
+                '2021-12-31T23:59:59',
+                'Lorem Ipsum consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+                'annual_performance_feedback_2023.cvs',
+                ),
+            (
+                __projects[2][0],
+                __blueprints[4][0],
+                '2021-09-15T19:00:00',
+                'Lorem Ipsum sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+                'efficiency_metrics_analysis_2023.txt',
+                ),
+            (
+                __projects[3][0],
+                __blueprints[5][0],
+                '2022-03-10T11:30:45',
+                'Lorem Ipsum sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+                'customer_feedback_analysis_2024.txt',
+                ),
+            (
+                __projects[4][0],
+                __blueprints[2][0],
+                '2023-06-20T16:45:00',
+                'Lorem Ipsum sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+                'efficiency_metrics_analysis_2023.txt',
+                ),
+            (
+                __projects[4][0],
+                __blueprints[4][0],
+                '2024-11-01T08:15:30',
+                'Lorem Ipsum sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+                'compliance_assessment_report_2024.txt',
+                ),
+        ]
+        __result_blueprint(__result_blueprint)
+
+
+
+    def __clear(self):
+        '''Clear database'''
+        self.db.debug_clear_all()
+
+    def __global(self):
+        '''Global settings'''
+        self.db.add_global_settings_node()
+
+    def __users(self, users):
+        '''User Settings'''
+        for user in users:
+            # Create nodes with email
+            id = self.db.add_user_settings_node(user[1])
+            if not user[0] == None:
+                self.db.set_user_settings_property(id, NodeProperties.UserSettings.NAME, user[0])
+
+    def __blueprints(self, blueprints):
+        '''Blueprints'''
         for blueprint in blueprints:
             id = self.db.add_blueprint_node()
-            self.db.set_blueprint_property(id, NodeProperties.Blueprint.NAME, blueprint[0])
-            self.db.set_blueprint_property(id, NodeProperties.Blueprint.DESCRIPTION, blueprint[1])
+            if not blueprint[0] == None:
+                self.db.set_blueprint_property(id, NodeProperties.Blueprint.NAME, blueprint[0])
+            if not blueprint[1] == None:
+                self.db.set_blueprint_property(id, NodeProperties.Blueprint.DESCRIPTION, blueprint[1])
+
+
+    def __projects(self, projects):
+        '''Projects'''
+        for project in projects:
+            id = self.db.add_project_node()
+            if not project[0] == None:
+                self.db.set_project_property(id, NodeProperties.Project.NAME, project[0])
+
+
+    def __result_blueprint(self, results):
+        '''Result-Blueprint'''
+        nodes = self.db.lookup_project_nodes()
+        for result in results:
+            id = self.db.add_result_blueprint_node()
+            # connect results to specific projects
+            for project_id, project_name in nodes:
+                if project_name == result[0]:
+                    self.db.connect_result_blueprint_to_project(id, project_id)
+                    # properties
+                    if not result[2] == None:
+                        self.db.set_result_blueprint_property(id, NodeProperties.ResultBlueprint.DATETIME, result[2])
+                    if not result[3] == None:
+                        self.db.set_result_blueprint_property(id, NodeProperties.ResultBlueprint.RESULT, result[3])
+                    if not result[4] == None:
+                        self.db.set_result_blueprint_property(id, NodeProperties.ResultBlueprint.FILENAME, result[4])
+
+
+                    
+            
 
 

--- a/backend/app/database_dummy.py
+++ b/backend/app/database_dummy.py
@@ -201,7 +201,7 @@ class DatabaseDummy:
                     # result -> project
                     self.db.connect_result_blueprint_to_project(result_id, project_id)
                     # used blueprint -> result
-                    used_blue_id = self.db.add_used_blueprint_node(blueprint_id)
+                    used_blue_id = self.db.copy_to_used_blueprint_node(blueprint_id)
                     self.db.connect_used_blueprint_to_result_blueprint(used_blue_id, result_id)
                     # properties
                     if not result[2] == None:

--- a/backend/app/database_dummy.py
+++ b/backend/app/database_dummy.py
@@ -1,0 +1,95 @@
+from database import Database, NodeProperties
+
+class DatabaseDummy:
+    '''Create pre-filled dummy database'''
+    def __init__(self):
+        '''Initialize'''
+        self.db = Database()
+
+        # clear all
+        self.__clear()
+
+        # global settings
+        self.__global()
+
+        # user settings
+        self.__users()
+
+        # blueprints
+        self.__blueprints()
+
+
+    def __clear(self):
+        '''Clear database'''
+        self.db.debug_clear_all()
+
+    def __global(self):
+        '''Global settings'''
+        self.db.add_global_settings_node()
+
+    def __users(self):
+        '''User Settings'''
+        # [(name, email)]
+        users = [
+            (
+                'John Smith',
+                'john.smith@example.com',
+                ),
+            (
+                'Jane Doe',
+                'jane.doe@example.com',
+                ),
+            (
+                'Emily Johnson',
+                'emily.johnson@example.com',
+                ),
+            (
+                'Michael Brown',
+                'michael.brown@example.com',
+                ),
+        ]
+        for user in users:
+            # Create nodes with email
+            id = self.db.add_user_settings_node(user[1])
+            self.db.set_user_settings_property(id, NodeProperties.UserSettings.NAME, user[0])
+
+    def __blueprints(self):
+        '''Blueprints'''
+        # [(name, description)]
+        blueprints = [
+            (
+                'Eduskunta',
+                'A collaborative framework designed to enhance educational dialogue and decision-making through structured discussions and feedback.',
+                ),
+            (
+                'Brainstorm Blueprint',
+                'A creative framework that uses guided questions to spark innovative ideas and foster collaborative thinking.',
+                ),
+            (
+                'Thought Explorer',
+                'A stimulating guide that encourages deep reflection and discovery through targeted questions and open-ended inquiries.',
+                ),
+            (
+                'Inquiry Adventure',
+                'An engaging toolkit designed to inspire curiosity and exploration through a series of thought-provoking questions.',
+                ),
+            (
+                'Dialogue Design',
+                'A structured approach that fosters meaningful conversations by providing a framework of insightful questions and prompts.',
+                ),
+            (
+                'Idea Igniter',
+                'A creative catalyst that sparks inspiration and generates innovative ideas through targeted prompts and questions.',
+                ),
+            (
+                'Question Quest',
+                'A playful exploration that drives discovery and insight through a series of engaging and thought-provoking questions.',
+                ),
+        ]
+
+        for blueprint in blueprints:
+            id = self.db.add_blueprint_node()
+            self.db.set_blueprint_property(id, NodeProperties.Blueprint.NAME, blueprint[0])
+            self.db.set_blueprint_property(id, NodeProperties.Blueprint.DESCRIPTION, blueprint[1])
+
+

--- a/backend/app/database_dummy.py
+++ b/backend/app/database_dummy.py
@@ -9,7 +9,7 @@ lorem_ipsum_questions = [
 ]
 
 class DatabaseDummy:
-    '''Create pre-filled dummy database
+    '''Creates pre-filled dummy database
     
     Warning. This will first clear the database.
     '''

--- a/backend/app/database_dummy.py
+++ b/backend/app/database_dummy.py
@@ -9,12 +9,15 @@ lorem_ipsum_questions = [
 ]
 
 class DatabaseDummy:
-    '''Create pre-filled dummy database'''
+    '''Create pre-filled dummy database
+    
+    Warning. This will first clear the database.
+    '''
     def __init__(self):
         '''
         When editing:
         - be sure to have all names unique for this example to work
-        - When adding new example properties to tuples, need to add code line for it further down.
+        - When adding new example properties to tuples, need to also add code line for it further down.
         '''
         self.db = Database()
 
@@ -22,11 +25,15 @@ class DatabaseDummy:
         self.__clear()
 
         ### global settings
+        #example:
+        # font and size
+        # __global = ('verdana', '10')
         __global = ()
         self.__global(__global)
 
         ### user settings
-        # [(name, email)]
+        # [(name,
+        #   email)]
         __users = [
             (
                 'John Smith',
@@ -48,7 +55,8 @@ class DatabaseDummy:
         self.__users(__users)
 
         ### blueprints
-        # [(name, description)]
+        # [(name,
+        #   description)]
         __blueprints = [
             (
                 'Eduskunta ',
@@ -112,7 +120,11 @@ class DatabaseDummy:
         ### Result-Blueprint
         # references __project names
         # references __blueprint names
-        # [(project-name, blueprint-name, datetime.iso(), result, filename)]
+        # [(project-name,
+        #   blueprint-name,
+        #   datetime.iso(),
+        #   result,
+        #   filename)]
         __result_blueprints = [
             (
                 __projects[1][0],
@@ -176,7 +188,7 @@ class DatabaseDummy:
         '''Global settings'''
         self.db.add_global_settings_node()
         # example
-        #self.db.set_global_settings_property(NodeProperties.GlobalSettings.NEWDATA, tuple[0])
+        #self.db.set_global_settings_property(NodeProperties.GlobalSettings.FONT, tuple[0])
 
     def __users(self, users):
         '''User Settings'''


### PR DESCRIPTION
closes #47 #86 

3 major things and one small:


1. #47:

Pre-filled database `(database_dummy.py)`

Usage:
```
from app.database_dummy import DatabaseDummy

DatabaseDummy()
```

Should be fairly easy to add new properties when needed

![image](https://github.com/user-attachments/assets/93807729-749e-49de-8e3c-e23409744340)

2. New public function to Database():
- copy_to_used_blueprint_node( blueprint_id ). Copies blueprint to used_blueprint variant.


3. #86  ([wiki](https://github.com/ProjectCED/CED-LLM/wiki/Database-design)): 
Code changes in `database.py`to commented out function: `def add_result_blueprint_node(self, project_id, blueprint_ids = None, dataset_list = None)`

Now only requires parent project id if converting to use this.

4. "Node type" should be named as "node label" (more official). Some changes (mostly comment changes).