### PR TITLE
Copy used blueprint to blueprint

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -114,8 +114,8 @@ class Database(metaclass=DatabaseMeta):
           - relationship types
         """
 
-        self.__driver = GraphDatabase.driver(os.getenv('NEO4J_URL'), auth=(os.getenv('NEO4J_USER'), os.getenv('NEO4J_PASSWORD')))
-        self.__name = os.getenv('NEO4J_DB_NAME')
+        self.__driver = GraphDatabase.driver(os.getenv('DB_URL'), auth=(os.getenv('DB_USERNAME'), os.getenv('DB_PASSWORD')))
+        self.__name = os.getenv('DB_NAME')
 
         self.__global_settings_type = 'Settings'
         self.__global_settings_id = 'name'
@@ -1660,6 +1660,22 @@ class Database(metaclass=DatabaseMeta):
         id = self.__add_node(self.__blueprint_type, self.__blueprint_id)
         self.set_blueprint_property(id, NodeProperties.Blueprint.DATETIME, datetime.now().isoformat())
         return id
+    
+    def copy_to_blueprint_node(self, used_blueprint_id_value):
+        """
+        Copies used blueprint node back to blueprint.
+
+        Args:
+            id_value (string): Value for the used blueprint id
+
+        Raises:
+            RuntimeError: If database query error.
+
+        Returns:
+            string: string containing ID value for the blueprint node. 
+        """
+        return self.__copy_node(self.__used_blueprint_type, self.__used_blueprint_id, used_blueprint_id_value, self.__blueprint_type, self.__blueprint_id)
+
 
 
     def set_blueprint_property(self, id_value, property_name: NodeProperties.DataModel, new_data):

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -50,6 +50,12 @@ class TestAddNode:
         result = db.add_blueprint_node()
         assert result != None
 
+    def test_blueprint_2(self,db:Database):
+        id = db.add_blueprint_node()
+        used_id = db.copy_to_used_blueprint_node(id)
+        result = db.copy_to_blueprint_node(used_id)
+        assert result != None
+
     def test_result_blueprint(self,db:Database):
         result = db.add_result_blueprint_node()
         assert result != None
@@ -57,7 +63,9 @@ class TestAddNode:
     def test_used_blueprint(self,db:Database):
         id = db.add_blueprint_node()
         result = db.copy_to_used_blueprint_node(id)
-        assert result != None       
+        assert result != None
+
+       
 
 
 class TestSetProperty:

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -1,6 +1,7 @@
 import pytest
 from app.database import Database, NodeProperties
 from datetime import datetime
+from uuid import UUID
 
 pytestmark = pytest.mark.database
 
@@ -44,26 +45,26 @@ class TestAddNode:
 
     def test_project(self,db:Database):
         result = db.add_project_node()
-        assert result != None
+        assert UUID(result,version=4)
 
     def test_blueprint(self,db:Database):
         result = db.add_blueprint_node()
-        assert result != None
+        assert UUID(result,version=4)
 
     def test_blueprint_2(self,db:Database):
         id = db.add_blueprint_node()
         used_id = db.copy_to_used_blueprint_node(id)
         result = db.copy_to_blueprint_node(used_id)
-        assert result != None
-
+        assert UUID(result,version=4)
+        
     def test_result_blueprint(self,db:Database):
         result = db.add_result_blueprint_node()
-        assert result != None
+        assert UUID(result,version=4)
 
     def test_used_blueprint(self,db:Database):
         id = db.add_blueprint_node()
         result = db.copy_to_used_blueprint_node(id)
-        assert result != None
+        assert UUID(result,version=4)
 
        
 
@@ -681,8 +682,8 @@ class TestNodeLookups:
         result = db.lookup_project_nodes()
 
         assert (
-            result[0][0] != None 
-            and result[1][0] != None 
+            UUID(result[0][0],version=4)
+            and UUID(result[1][0],version=4)
             and result[0][1] == 'foo_1' 
             and result[1][1] == 'foo_2'
             and self.helper_datetime_checker(result[0][2]) == True 
@@ -698,8 +699,8 @@ class TestNodeLookups:
         result = db.lookup_blueprint_nodes()
 
         assert (
-            result[0][0] != None 
-            and result[1][0] != None 
+            UUID(result[0][0],version=4)
+            and UUID(result[1][0],version=4)
             and result[0][1] == 'foo_1' 
             and result[1][1] == 'foo_2'
             and self.helper_datetime_checker(result[0][2]) == True 
@@ -717,8 +718,8 @@ class TestNodeLookups:
         result = db.lookup_result_blueprint_nodes(id)
 
         assert (
-            result[0][0] != None 
-            and result[1][0] != None 
+            UUID(result[0][0],version=4)
+            and UUID(result[1][0],version=4)
             and self.helper_datetime_checker(result[0][1]) == True 
             and self.helper_datetime_checker(result[1][1]) == True
         )


### PR DESCRIPTION
closes #133

1 major, 2 minor

Added `db.copy_to_blueprint_node(used_blueprint_id)` to database-class
- Used for copying used_blueprint from some result into usable blueprint.

Added one test for this new function.

Added UUID testing for node creations. Replaces old "!= None" testing.

