### PR TITLE
Docker cors hotfix

### DIFF
--- a/.env.example (backend)
+++ b/.env.example (backend)
@@ -1,5 +1,5 @@
 JWT_SECRET_KEY=your_jwt_secret_key
-DB_URL=bolt://localhost:7687
+DB_URL=bolt://neo4j:7687
 DB_USERNAME=neo4j #with neo4j community version, this is locked to 'neo4j'
 DB_PASSWORD=password
 DB_NAME=neo4j

--- a/.env.example (frontend)
+++ b/.env.example (frontend)
@@ -1,5 +1,3 @@
-REACT_APP_API_URL=http://backend:5000/api # docker usage
-#REACT_APP_API_URL=http://localhost:5000/api #non-docker usage
-VITE_BACKEND_URL=http://backend:5000 # docker usage
-#VITE_BACKEND_URL=http://localhost:5000 #non-docker usage
+REACT_APP_API_URL=http://localhost:5000/api #non-docker usage
+VITE_BACKEND_URL=http://localhost:5000 #non-docker usage
 VITE_PORT=5173 # user primary access

--- a/.env.example (frontend)
+++ b/.env.example (frontend)
@@ -1,1 +1,5 @@
-REACT_APP_API_URL=http://localhost:5000/api
+REACT_APP_API_URL=http://backend:5000/api # docker usage
+#REACT_APP_API_URL=http://localhost:5000/api #non-docker usage
+VITE_BACKEND_URL=http://backend:5000 # docker usage
+#VITE_BACKEND_URL=http://localhost:5000 #non-docker usage
+VITE_PORT=5173 # user primary access

--- a/.env.example (frontend)
+++ b/.env.example (frontend)
@@ -1,3 +1,2 @@
 REACT_APP_API_URL=http://localhost:5000/api #non-docker usage
-VITE_BACKEND_URL=http://localhost:5000 #non-docker usage
 VITE_PORT=5173 # user primary access

--- a/backend/app/backend_api.py
+++ b/backend/app/backend_api.py
@@ -2,6 +2,7 @@ from flask import jsonify, Blueprint, request
 from flask_cors import CORS
 from app.api_handler import ApiHandler
 from app.database import Database, NodeProperties
+from dotenv import load_dotenv
 import os
 from app.models.blueprint import Blueprint as BP
 
@@ -9,7 +10,8 @@ main = Blueprint('main', __name__)
 apiHandler = ApiHandler()
 database = Database()
 
-CORS(main)  # Allows connections between domains
+frontend_port = os.getenv('VITE_PORT', '5173')
+CORS(main, resources={r"/*": {"origins": "http://localhost:{frontend_port}"}})  # Allows connections between domains
 
 # File management
 @main.route('/analyze', methods=['POST']) 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,10 +26,10 @@ services:
 
   backend:
     build: ./backend
-#    ports:
-#      - "5000:5000" # Communication with frontend
-    expose:
-      - "5000" # Communication with frontend
+    ports:
+      - "5000:5000" # Communication with frontend
+#    expose:
+#      - "5000" # Communication with frontend
     environment:
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
       - DB_URL=${DB_URL}
@@ -54,11 +54,11 @@ services:
 
   neo4j:
     image: neo4j:5.25-community
-#    ports:
-      #- "7433:7433" #changed from normal 7474 because of conflict somewhere. Only for admin interface access through browser.
-#      - "7687:7687"
-    expose:
-      - "7687" # Communication with backend
+    ports:
+      - "7433:7433" #changed from normal 7474 because of conflict somewhere. Only for admin interface access through browser.
+      - "7687:7687"
+#    expose:
+#      - "7687" # Communication with backend
     environment:
       - NEO4J_initial.dbms.default_database=${DB_NAME}
       #- NEO4J_ACCEPT_LICENSE_AGREEMENT=yes # possibly only needed for enterprise version

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 #      - '3000' # TODO: label this
     environment:
       - REACT_APP_API_URL=${REACT_APP_API_URL}
-      - VITE_BACKEND_URL=${VITE_BACKEND_URL}
+      - VITE_BACKEND_URL=http://backend:5000
       - VITE_PORT=${VITE_PORT}
     depends_on:
       backend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 #    expose:
 #      - '3000' # TODO: label this
     environment:
-      - REACT_APP_API_URL=${REACT_APP_API_URL}
+      - REACT_APP_API_URL=http://backend:5000/api
       - VITE_BACKEND_URL=http://backend:5000
       - VITE_PORT=${VITE_PORT}
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,14 @@ services:
     build: ./frontend
     ports:
 #      - "3000:3000" # TODO: label this
-      - "5173:5173" # primary user access to application
+#      - "5173:5173" # primary user access to application
+      - "${VITE_PORT:-5173}:${VITE_PORT:-5173}"
 #    expose:
 #      - '3000' # TODO: label this
     environment:
-      - REACT_APP_API_URL=http://localhost:5000/api
+      - REACT_APP_API_URL=${REACT_APP_API_URL}
+      - VITE_BACKEND_URL=${VITE_BACKEND_URL}
+      - VITE_PORT=${VITE_PORT}
     depends_on:
       backend:
         condition: service_healthy
@@ -28,8 +31,8 @@ services:
   backend:
     container_name: backend
     build: ./backend
-    ports:
-      - "5000:5000" # Communication with frontend
+#    ports:
+#      - "5000:5000" # Communication with frontend
     expose:
       - "5000" # Communication with frontend
     environment:
@@ -39,6 +42,7 @@ services:
       - DB_USERNAME=neo4j #locked to 'neo4j' in community version
       - DB_PASSWORD=${DB_PASSWORD}
       - OPENAI_KEY=${OPENAI_KEY}
+      - VITE_PORT=${VITE_PORT}
     depends_on:
       neo4j:
         

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
     expose:
       - "7687" # Communication with backend
     environment:
-      - NEO4J_initial.dbms.default_database=${DB_NAME}
+      - NEO4J_initial.dbms.default_database=neo4j
       #- NEO4J_ACCEPT_LICENSE_AGREEMENT=yes # possibly only needed for enterprise version
       - NEO4J_AUTH=neo4j/${DB_PASSWORD}
       # memory setup for "light weight application"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,8 @@ services:
       - "5000" # Communication with frontend
     environment:
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
-      - DB_URL=${DB_URL}
-      - DB_NAME=${DB_NAME}
+      - DB_URL=bolt://neo4j:7687
+      - DB_NAME=neo4j
       - DB_USERNAME=neo4j #locked to 'neo4j' in community version
       - DB_PASSWORD=${DB_PASSWORD}
       - OPENAI_KEY=${OPENAI_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ networks:
 
 services:
   frontend:
+    container_name: frontend
     build: ./frontend
     ports:
 #      - "3000:3000" # TODO: label this
@@ -25,11 +26,12 @@ services:
 
 
   backend:
+    container_name: backend
     build: ./backend
     ports:
       - "5000:5000" # Communication with frontend
-#    expose:
-#      - "5000" # Communication with frontend
+    expose:
+      - "5000" # Communication with frontend
     environment:
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
       - DB_URL=${DB_URL}
@@ -39,12 +41,13 @@ services:
       - OPENAI_KEY=${OPENAI_KEY}
     depends_on:
       neo4j:
+        
         condition: service_healthy
     networks:
       - backend
       - database
     healthcheck:
-      #test: ["CMD", "nc", "-z", "host.docker.internal", "5000"] # check if port is open
+      #test: ["CMD", "nc", "-z", "localhost", "5000"] # check if port is open
       test: ["CMD", "nc", "-z", "backend", "5000"] # check if port is open
       interval: 3s
       timeout: 3s
@@ -53,12 +56,13 @@ services:
 
 
   neo4j:
+    container_name: neo4j
     image: neo4j:5.25-community
-    ports:
-      - "7433:7433" #changed from normal 7474 because of conflict somewhere. Only for admin interface access through browser.
-      - "7687:7687"
-#    expose:
-#      - "7687" # Communication with backend
+#    ports:
+#      - "7433:7433" #changed from normal 7474 because of conflict somewhere. Only for admin interface access through browser.
+#      - "7687:7687"
+    expose:
+      - "7687" # Communication with backend
     environment:
       - NEO4J_initial.dbms.default_database=${DB_NAME}
       #- NEO4J_ACCEPT_LICENSE_AGREEMENT=yes # possibly only needed for enterprise version

--- a/frontend/frontend_api.js
+++ b/frontend/frontend_api.js
@@ -5,7 +5,7 @@ function App() {
 
   const handleAnalyze = () => {
     // Send POST-request to backend
-    fetch('http://localhost:5000/analyze', {
+    fetch('/api/analyze', {
       method: 'POST',
     })
       .then((response) => response.json())

--- a/frontend/src/utils.jsx
+++ b/frontend/src/utils.jsx
@@ -1,5 +1,5 @@
 export const getBlueprints = async () => {
-    const response = await fetch('http://127.0.0.1:5000/get_blueprints', {
+    const response = await fetch('/api/get_blueprints', {
       method: 'GET'
     }); 
     const blueprints = await response.json();
@@ -7,7 +7,7 @@ export const getBlueprints = async () => {
 };
 
 export const analyzeUploadedFile = async (filename) => {
-const response = await fetch('http://127.0.0.1:5000/analyze_file', {
+const response = await fetch('/api/analyze_file', {
     method: 'POST',
     body: filename,
     });
@@ -18,7 +18,7 @@ const response = await fetch('http://127.0.0.1:5000/analyze_file', {
 };
 
 export const saveBlueprint = async (blueprint) => {
-    const response = await fetch('http://127.0.0.1:5000/save_blueprint', {
+    const response = await fetch('/api/save_blueprint', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'
@@ -30,7 +30,7 @@ export const saveBlueprint = async (blueprint) => {
 };
 
 export const deleteBlueprint = async (id) => {
-  const response = await fetch('http://127.0.0.1:5000/delete_blueprint', {
+  const response = await fetch('/api/delete_blueprint', {
       method: 'POST',
       headers: {
           'Content-Type': 'application/json'

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: process.env.VITE_BACKEND_URL,
+        target: process.env.VITE_BACKEND_URL || 'http://localhost:5000',
         rewrite: (path) => path.replace(/^\/api/, ''), // Remove `/api` prefix
       },
     },

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,7 +6,11 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/api': 'http://localhost:5000',
+      '/api': {
+        target: process.env.VITE_BACKEND_URL,
+        rewrite: (path) => path.replace(/^\/api/, ''), // Remove `/api` prefix
+      },
     },
+    port: process.env.VITE_PORT || 5173,
   },
 })


### PR DESCRIPTION
Database connectivity fixed with giving containers static names

CORS fixed by allowing localhost:{frontend_port} as origin in backend (backend_api.py)

Added VITE_BACKEND_URL to manage docker <-> non-docker development. Doesn't need to be added to .env.

Added VITE_PORT to manage which port does the program give access. Optional to have it in .env, defaults to 5173 if not set.


