### PR TITLE
docker compose fine tuning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,10 +69,10 @@ services:
       - "7687" # Communication with backend
     environment:
       - NEO4J_initial.dbms.default_database=neo4j
-      #- NEO4J_ACCEPT_LICENSE_AGREEMENT=yes # possibly only needed for enterprise version
+      #- NEO4J_ACCEPT_LICENSE_AGREEMENT=yes # only needed for enterprise version
       - NEO4J_AUTH=neo4j/${DB_PASSWORD}
       # memory setup for "light weight application"
-      - NEO4J_server.dbms.usage_report.enabled=false # disables anonymouse usage data
+      - NEO4J_server.dbms.usage_report.enabled=false # disables anonymouse usage data https://neo4j.com/docs/reference/usage-data/
       - NEO4J_server.memory.heap.initial_size=512M  # Initial heap size
       - NEO4J_server.memory.heap.max_size=1G  # Max heap size
       - NEO4J_server.memory.pagecache.size=512M  # Page cache size

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,7 @@ services:
     build: ./frontend
     ports:
 #      - "3000:3000" # TODO: label this
-#      - "5173:5173" # primary user access to application
-      - "${VITE_PORT:-5173}:${VITE_PORT:-5173}"
+      - "${VITE_PORT:-5173}:${VITE_PORT:-5173}" # defaults to 5173
 #    expose:
 #      - '3000' # TODO: label this
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     build: ./frontend
     ports:
 #      - "3000:3000" # TODO: label this
-      - "${VITE_PORT:-5173}:${VITE_PORT:-5173}" # defaults to 5173
+      - "${VITE_PORT:-5173}:${VITE_PORT:-5173}" # primary user access, defaults to 5173
 #    expose:
 #      - '3000' # TODO: label this
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,9 +62,9 @@ services:
   neo4j:
     container_name: neo4j
     image: neo4j:5.25-community
-#    ports:
-#      - "7433:7433" #changed from normal 7474 because of conflict somewhere. Only for admin interface access through browser.
-#      - "7687:7687"
+    # ports:
+    #   - "7474:7474" #changed from normal 7474 because of conflict somewhere. Only for admin interface access through browser.
+    #   - "7687:7687"
     expose:
       - "7687" # Communication with backend
     environment:
@@ -72,6 +72,7 @@ services:
       #- NEO4J_ACCEPT_LICENSE_AGREEMENT=yes # possibly only needed for enterprise version
       - NEO4J_AUTH=neo4j/${DB_PASSWORD}
       # memory setup for "light weight application"
+      - NEO4J_server.dbms.usage_report.enabled=false # disables anonymouse usage data
       - NEO4J_server.memory.heap.initial_size=512M  # Initial heap size
       - NEO4J_server.memory.heap.max_size=1G  # Max heap size
       - NEO4J_server.memory.pagecache.size=512M  # Page cache size

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,8 +62,8 @@ services:
     container_name: neo4j
     image: neo4j:5.25-community
     # ports:
-    #   - "7474:7474" #changed from normal 7474 because of conflict somewhere. Only for admin interface access through browser.
-    #   - "7687:7687"
+    #   - "7474:7474" # For admin interface access through browser
+    #   - "7687:7687" # bolt communication
     expose:
       - "7687" # Communication with backend
     environment:


### PR DESCRIPTION
Small changes so far:

- Reverted to use normal port for http browser access (7474), this is still commented out for normal usage
- disabled anonymous usage data