### PR TITLE
Database add default sorting to lists

### DIFF
--- a/.env.example (backend)
+++ b/.env.example (backend)
@@ -1,5 +1,5 @@
 JWT_SECRET_KEY=your_jwt_secret_key
-DB_URL=bolt://neo4j:7687
+DB_URL=bolt://localhost:7687
 DB_USERNAME=neo4j #with neo4j community version, this is locked to 'neo4j'
 DB_PASSWORD=password
 DB_NAME=neo4j

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1377,7 +1377,8 @@ class Database(metaclass=DatabaseMeta):
         Lookup Projects and return list of them in a [[ID, NAME, DATETIME]] combo. Sorting the result by DATETIME DESC.
 
         Raises:
-            RuntimeError: If database query error.   
+            RuntimeError: If database query error.
+            RuntimeError: If an invalid sort_direction value is provided (should not occur).
 
         Returns:
             list[string, string, string] or None:
@@ -1754,7 +1755,8 @@ class Database(metaclass=DatabaseMeta):
         Lookup Blueprints and return list of them in a [[ID, NAME, DATETIME]] combo. Sorting the result by DATETIME DESC.
 
         Raises:
-            RuntimeError: If database query error.   
+            RuntimeError: If database query error.
+            RuntimeError: If an invalid sort_direction value is provided (should not occur).
 
         Returns:
             list[string, string] or None:
@@ -2221,7 +2223,8 @@ class Database(metaclass=DatabaseMeta):
             project_id (string): Value for the id
 
         Raises:
-            RuntimeError: If database query error.   
+            RuntimeError: If database query error.
+            RuntimeError: If an invalid sort_direction value is provided (should not occur).
 
         Returns:
             list[string, DATETIME.ISO] or None:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -9,6 +9,8 @@ class NodeProperties:
     """All allowed property names for each node label.
 
     Add more properties here when needed, but check Database class init for reserved names for identifier usage before adding new property names.
+
+    When adding properties that should be used with sorting the lists. They also need to be added to 'sorting_properties'-variable in __lookup_nodes().
     """
     class GlobalSettings(Enum):
         # Settings

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -402,14 +402,12 @@ class Database(metaclass=DatabaseMeta):
         """
         # sorting string
         sorting_string = '' # this will be used if no sorting property detected
-        # sorting_properties = ['datetime'] # add more here when adding more properties that you want to sort by TODO: perhaps do some form of ENUM from this
-        # sorting_property = next((prop for prop in sorting_properties if prop in property_list), None) # first hit chosen
         if (sort_direction != 'DESC' and sort_direction != 'ASC'):
             raise RuntimeError( "__lookup_nodes() sort_direction invalid value: " + sort_direction )
-        
         if sort_property:
             sorting_string = f"WITH n ORDER BY n.{sort_property} {sort_direction} "
 
+        # make string from property list
         property_list_string = ''
         for item in property_list:
             property_list_string = property_list_string + ", n." + item

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -720,6 +720,8 @@ class TestNodeLookups:
         assert (
             UUID(result[0][0],version=4)
             and UUID(result[1][0],version=4)
+            and result[0][0] == id_2 # order matters
+            and result[1][0] == id_1
             and self.helper_datetime_checker(result[0][1]) == True 
             and self.helper_datetime_checker(result[1][1]) == True
         )

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -1,3 +1,23 @@
+"""
+Database testing. Combined unit- and integration-testing. 
+
+Tests is done by using database() public functions and it's queries instead of creating new connection in this module.
+
+Modules tested:
+- Database public functions
+- Partially Database private functions (that used by public functions)
+- Communication with real database.
+
+Usage:
+- "$env:PYTHONPATH = (Get-Location).Path" command in backend-folder (windows11)
+- "pytest -m database -p no:warnings" command in backend-folder
+
+Note: make sure database is up and running either:
+- Through Neo4j Desktop (official app)
+- Editing neo4j ports back in in docker-compose.yml and launching with "docker-compose up neo4j --build"
+
+"""
+
 import pytest
 from app.database import Database, NodeProperties
 from datetime import datetime
@@ -10,9 +30,6 @@ def db():
     """
     Fixture that sets up a real database connection for the entire module.
     This connection will be shared across all tests in this module.
-
-    Tests is done by using database() public functions and it's queries,
-    instead of making separate queries from here.
 
     Returns:
         database object

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -684,8 +684,8 @@ class TestNodeLookups:
         assert (
             UUID(result[0][0],version=4)
             and UUID(result[1][0],version=4)
-            and result[0][1] == 'foo_1' 
-            and result[1][1] == 'foo_2'
+            and result[0][1] == 'foo_2' # order matters
+            and result[1][1] == 'foo_1'
             and self.helper_datetime_checker(result[0][2]) == True 
             and self.helper_datetime_checker(result[1][2]) == True
         )
@@ -701,8 +701,8 @@ class TestNodeLookups:
         assert (
             UUID(result[0][0],version=4)
             and UUID(result[1][0],version=4)
-            and result[0][1] == 'foo_1' 
-            and result[1][1] == 'foo_2'
+            and result[0][1] == 'foo_2' # order matters
+            and result[1][1] == 'foo_1'
             and self.helper_datetime_checker(result[0][2]) == True 
             and self.helper_datetime_checker(result[1][2]) == True
         )


### PR DESCRIPTION
#144 

Main addition:
- Lists sorted with provided property_name (optional). Used by public functions. No changes needed outside of Database. Currently everything is sorted by 'datetime' DESC.

Extra additions:
- Database tests updated
- Module documentation for database tests
- example .env fix for database url (neo4j:7687 -> localhost:7687)