### PR TITLE
Docker-compose: Neo4j fix for anonymouse data sending

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,6 @@ services:
       #- NEO4J_ACCEPT_LICENSE_AGREEMENT=yes # only needed for enterprise version
       - NEO4J_AUTH=neo4j/${DB_PASSWORD}
       # memory setup for "light weight application"
-      - NEO4J_server.dbms.usage_report.enabled=false # disables anonymouse usage data https://neo4j.com/docs/reference/usage-data/
       - NEO4J_server.memory.heap.initial_size=512M  # Initial heap size
       - NEO4J_server.memory.heap.max_size=1G  # Max heap size
       - NEO4J_server.memory.pagecache.size=512M  # Page cache size
@@ -86,6 +85,7 @@ services:
       interval: 10s
       retries: 5
     volumes:
+      - ./neo4j/neo4j.conf:/conf/neo4j.conf:ro  # Read-only mount, disables anonymouse usage data https://neo4j.com/docs/reference/usage-data/
       - neo4j_data:/data   # Persist database data
       - neo4j_logs:/logs   # Persist logs
       - neo4j_plugins:/plugins  # Directory for plugins (optional)

--- a/neo4j/neo4j.conf
+++ b/neo4j/neo4j.conf
@@ -1,0 +1,1 @@
+dbms.usage_report.enabled=false


### PR DESCRIPTION
Old setting doesn't seem to work for some reason. New way is to look for the setting in neo4j.conf file in read-only mode (neo4j image likes to update it with bad settings and fail the next time doing compose up).

at least at this moment
![image](https://github.com/user-attachments/assets/4acc2b0e-f6c2-4a84-9f5a-5dcb6b06cdf0)
![image](https://github.com/user-attachments/assets/c9258bfa-129d-4e8c-87b1-e7ddc7136af4)

it seemed to have worked and restarting the container also works fine.