### PR TITLE
Docker compose changes to ollama

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,8 +120,8 @@ services:
         max-size: "10m"
         max-file: "3"
     volumes:
-      - ./ollama/entrypoint.sh:/entrypoint.sh
-      - ollama:/root/.ollama
+      - ./ollama/entrypoint.sh:/entrypoint.sh # Mistral automatically loaded (mainly for initial start)
+      - ollama:/root/.ollama # Mistral stored for quick restart
     entrypoint: ["/usr/bin/bash", "/entrypoint.sh"]
     networks:
       - llm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,10 +120,15 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+    volumes:
+      - ./ollama/entrypoint.sh:/entrypoint.sh
+      - ollama:/root/.ollama
+    entrypoint: ["/usr/bin/bash", "/entrypoint.sh"]
     networks:
       - llm
-      
+
 volumes:
   neo4j_data:
   neo4j_logs:
   neo4j_plugins:
+  ollama:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,9 +120,9 @@ services:
         max-size: "10m"
         max-file: "3"
     volumes:
-      - ./ollama/entrypoint.sh:/entrypoint.sh # Mistral automatically loaded (mainly for initial start)
+      - ./ollama/entrypoint.sh:/entrypoint.sh
       - ollama:/root/.ollama # Mistral stored for quick restart
-    entrypoint: ["/usr/bin/bash", "/entrypoint.sh"]
+    entrypoint: ["/usr/bin/bash", "/entrypoint.sh"] # Mistral automatically loaded (mainly for initial start)
     networks:
       - llm
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,8 +48,8 @@ services:
     depends_on:
       neo4j:
         condition: service_healthy
-      # ollama:
-      #   condition: service_healthy
+      ollama:
+        condition: service_healthy
     networks:
       - backend
       - database
@@ -109,12 +109,11 @@ services:
       - ${GPU_VISIBLE_DEVICES:-NVIDIA_VISIBLE_DEVICES}=all
       - ${GPU_DRIVER_CAPABILITIES:-NVIDIA_DRIVER_CAPABILITIES}=compute,utility
     healthcheck:
-      test: ollama list || exit 1
+      test: ollama list | grep -q mistral || exit 1 # check that mistral is installed by entrypoint.sh
       interval: 10s
       timeout: 30s
-      retries: 5
+      retries: 50 # if download speed is really slow (~4GB), you might want to increase this or do the entrypoint.sh manually
       start_period: 5s
-    # workaround on healthcheck spam not making log too large
     logging:
       driver: "json-file"
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
     # Mistral automatically loaded (mainly for initial start)
     # Can also be done manually with more progress information:
     #   docker exec -it ollama /bin/bash -c "ollama run mistral"
-    # Remember to comment out entrypoint.sh before doing it manually
+    # Remember to comment out entrypoint before doing it manually
     entrypoint: ["/usr/bin/bash", "/entrypoint.sh"] 
     networks:
       - llm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,11 @@ services:
     volumes:
       - ./ollama/entrypoint.sh:/entrypoint.sh
       - ollama:/root/.ollama # Mistral stored for quick restart
-    entrypoint: ["/usr/bin/bash", "/entrypoint.sh"] # Mistral automatically loaded (mainly for initial start)
+    # Mistral automatically loaded (mainly for initial start)
+    # Can also be done manually with more progress information:
+    #   docker exec -it ollama /bin/bash -c "ollama run mistral"
+    # Remember to comment out entrypoint.sh before doing it manually
+    entrypoint: ["/usr/bin/bash", "/entrypoint.sh"] 
     networks:
       - llm
 

--- a/ollama/entrypoint.sh
+++ b/ollama/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Start Ollama in the background.
+/bin/ollama serve &
+# Record Process ID.
+pid=$!
+
+# Pause for Ollama to start.
+sleep 5
+
+echo "🔴 Retrieve Mistral model..."
+ollama run mistral
+echo "🟢 Done!"
+
+# Wait for Ollama process to finish.
+wait $pid


### PR DESCRIPTION
#N/A
Added volume for ollama container so it can remember mistral when restarting.

#N/A
Added script to automatically run mistral on docker-compose up. However, this will take awhile to install (4GB download). Healthcheck will currently retry 10s * 50retry = 500 seconds until it decides that container is unhealthy. Backend will wait for ollama.

Added this notice to [wiki](https://github.com/ProjectCED/CED-LLM/wiki/Docker-compose):
**NOTICE:** When running with local Mistral(ollama container), the container needs to install Mistral after it's up. Backend will be waiting up to 500 seconds for ollama to become healthy. Ollama will need to download ~4GB on first run. Mistral will be stored in volume so restarts will be fast.